### PR TITLE
ACC update - hex code refactor 

### DIFF
--- a/data/AssettoCorsaCompetizione/audi_r8_lms_gt2.json
+++ b/data/AssettoCorsaCompetizione/audi_r8_lms_gt2.json
@@ -1,10 +1,10 @@
 {
-    "name": "AUDI R8 LMS GT2 2021",
+    "carName": "AUDI R8 LMS GT2 2021",
     "carId": "audi_r8_lms_gt2",
     "carClass": "GT2",
     "ledNumber": 10,
     "redlineBlinkInterval": 0,
-    "ledColor": [ "#FF0000","#00FF00","#00FF00","#00FF00","#FFFF00","#FFFF00","#FFFF00","#FFFF00","#FF0000","#FF0000","#FF0000" ],
+    "ledColor": [ "#FFFF0000","#FF00FF00","#FF00FF00","#FF00FF00","#FFFFFF00","#FFFFFF00","#FFFFFF00","#FFFFFF00","#FFFF0000","#FFFF0000","#FFFF0000" ],
     "ledRpm": [
         {
             "R": [ 8400, 6400, 6700, 7000, 7200, 7400, 7600, 7800, 8000, 8200, 8400 ],

--- a/data/AssettoCorsaCompetizione/bmw_m2_cs_racing.json
+++ b/data/AssettoCorsaCompetizione/bmw_m2_cs_racing.json
@@ -1,10 +1,10 @@
 {
-    "name": "BMW m2 CUP 2020",
+    "carName": "BMW m2 CUP 2020",
     "carId": "bmw_m2_cs_racing",
     "carClass": "TCX",
     "ledNumber": 10,
     "redlineBlinkInterval": 250,
-    "ledColor": [ "blue", "green", "green", "green", "green", "yellow", "yellow", "orange", "orange", "#FA0000", "#FA0000" ],
+    "ledColor": [ "#00000000", "#FF00FF00", "#FF00FF00", "#FFFFFF00", "#FFFFFF00", "#FFFF0000", "#FFFF0000", "#FFFFFF00", "#FFFFFF00", "#FF00FF00", "#FF00FF00" ],
     "ledRpm": [
         {
             "R": [ 7200, 6400, 6600, 6800, 7000, 7200, 7200, 7000, 6800, 6600, 6400 ],

--- a/data/AssettoCorsaCompetizione/ferrari_488_challenge_evo.json
+++ b/data/AssettoCorsaCompetizione/ferrari_488_challenge_evo.json
@@ -4,7 +4,7 @@
   "carClass": "GTC",
   "ledNumber": 4,
   "redlineBlinkInterval": 250,
-  "ledColor": ["#00000000","#00FF00","#00FF00","#00FF00","#FF0000"],
+  "ledColor": ["#00000000","#FF00FF00","#FF00FF00","#FF00FF00","#FFFF0000"],
   "ledRpm": [
     {
       "R": [ 7800, 7300, 7400, 7500, 7600 ],

--- a/data/AssettoCorsaCompetizione/ktm_xbow_gt2.json
+++ b/data/AssettoCorsaCompetizione/ktm_xbow_gt2.json
@@ -1,10 +1,10 @@
 {
-    "name": "KTM XBOW GT2 2021",
+    "carNme": "KTM XBOW GT2 2021",
     "carId": "ktm_xbow_gt2",
     "carClass": "GT2",
     "ledNumber": 8,
     "redlineBlinkInterval": 250,
-    "ledColor": [ "#000000", "#FF0000", "#FF0000", "#FF0000", "#FF0000", "#FF0000", "#FF0000", "#FF0000", "#FF0000" ],
+    "ledColor": [ "#00000000", "#FFFF0000", "#FFFF0000", "#FFFF0000", "#FFFF0000", "#FFFF0000", "#FFFF0000", "#FFFF0000", "#FFFF0000" ],
     "ledRpm": [
         {
             "R": [ 7100, 6100, 6100, 6500, 6500, 6900, 6900, 6900, 6900 ],

--- a/data/AssettoCorsaCompetizione/lamborghini_huracan_st.json
+++ b/data/AssettoCorsaCompetizione/lamborghini_huracan_st.json
@@ -4,7 +4,7 @@
   "carClass": "ST",
   "ledNumber": 8,
   "redlineBlinkInterval": 250,
-  "ledColor": ["#00000000","#00FF00","#0000FF","#FFFF00","#FF0000","#FF0000","#FFFF00","#0000FF","#00FF00"],
+  "ledColor": ["#00000000","#FF00FF00","#FF0000FF","#FFFFFF00","#FFFF0000","#FFFF0000","#FFFFFF00","#FF0000FF","#FF00FF00"],
   "ledRpm": [
     {
       "R": [ 7900, 6200, 6800, 7100, 7400, 7400, 7100, 6800, 6200 ],

--- a/data/AssettoCorsaCompetizione/lamborghini_huracan_st_evo2.json
+++ b/data/AssettoCorsaCompetizione/lamborghini_huracan_st_evo2.json
@@ -4,7 +4,7 @@
   "carClass": "ST",
   "ledNumber": 8,
   "redlineBlinkInterval": 250,
-  "ledColor": ["#00000000","#00FF00","#0000FF","#FFFF00","#FF0000","#FF0000","#FFFF00","#0000FF","#00FF00"],
+  "ledColor": ["#00000000","#FF00FF00","#FF0000FF","#FFFFFF00","#FFFF0000","#FFFF0000","#FFFFFF00","#FF0000FF","#FF00FF00"],
   "ledRpm": [
     {
       "R": [ 8400, 7600, 7800, 8000, 8200, 8200, 8000, 7800, 7600 ],

--- a/data/AssettoCorsaCompetizione/maserati_mc20_gt2.json
+++ b/data/AssettoCorsaCompetizione/maserati_mc20_gt2.json
@@ -1,10 +1,10 @@
 {
-    "name": "MASERATI GT2 2023",
+    "carName": "MASERATI GT2 2023",
     "carId": "maserati_mc20_gt2",
     "carClass": "GT2",
     "ledNumber": 8,
     "redlineBlinkInterval": 250,
-    "ledColor": [ "#0000FF", "#00FF00", "#00FF00", "#FFFF00", "#FFFF00", "#FFFF00", "#FFFF00", "#FF0000", "#FF0000" ],
+    "ledColor": [ "#FF0000FF", "#FF00FF00", "#FF00FF00", "#FFFFFF00", "#FFFFFF00", "#FFFFFF00", "#FFFFFF00", "#FFFF0000", "#FFFF0000" ],
     "ledRpm": [
         {
             "R": [ 7650, 5500, 5900, 6200, 6400, 6700, 6900, 7200, 7400 ],

--- a/data/AssettoCorsaCompetizione/mercedes_amg_gt2.json
+++ b/data/AssettoCorsaCompetizione/mercedes_amg_gt2.json
@@ -1,10 +1,10 @@
 {
-    "name": "MERCEDES AMG GT2 2023",
+    "carNme": "MERCEDES AMG GT2 2023",
     "carId": "mercedes_amg_gt2",
     "carClass": "GT2",
     "ledNumber": 8,
     "redlineBlinkInterval": 250,
-    "ledColor": [ "#FF0000", "#00FF00", "#FFFF00", "#FFFF00", "#FF0000", "#FF0000", "#FFFF00", "#FFFF00", "#00FF00" ],
+    "ledColor": [ "#FFFF0000", "#FF00FF00", "#FFFFFF00", "#FFFFFF00", "#FFFF0000", "#FFFF0000", "#FFFFFF00", "#FFFFFF00", "#FF00FF00" ],
     "ledRpm": [
         {
             "R": [ 7000, 6000, 6300, 6600, 6800, 6800, 6600, 6300, 6000 ],

--- a/data/AssettoCorsaCompetizione/porsche_935.json
+++ b/data/AssettoCorsaCompetizione/porsche_935.json
@@ -4,7 +4,7 @@
   "carClass": "GT2",
   "ledNumber": 8,
   "redlineBlinkInterval": 120,
-  "ledColor": ["#0000FF","#00FF00","#00FF00","#00FF00","#FFFF00","#FFFF00","#FFFF00","#FF0000","#FF0000"],
+  "ledColor": ["#FF0000FF","#FF00FF00","#FF00FF00","#FF00FF00","#FFFFFF00","#FFFFFF00","#FFFFFF00","#FFFF0000","#FFFF0000"],
   "ledRpm": [
     {
       "R": [ 6900, 6000, 6200, 6400, 6500, 6600, 6700, 6800, 6900 ],

--- a/data/AssettoCorsaCompetizione/porsche_991_gt2_rs_mr.json
+++ b/data/AssettoCorsaCompetizione/porsche_991_gt2_rs_mr.json
@@ -4,7 +4,7 @@
   "carClass": "GT2",
   "ledNumber": 8,
   "redlineBlinkInterval": 120,
-  "ledColor": ["#0000FF","#00FF00","#00FF00","#00FF00","#FFFF00","#FFFF00","#FFFF00","#FF0000","#FF0000"],
+  "ledColor": ["#FF0000FF","#FF00FF00","#FF00FF00","#FF00FF00","#FFFFFF00","#FFFFFF00","#FFFFFF00","#FFFF0000","#FFFF0000"],
   "ledRpm": [
     {
       "R": [ 6900, 6000, 6200, 6400, 6500, 6600, 6700, 6800, 6900 ],


### PR DESCRIPTION
Incorrect 6 digit hex color codes used. Switched to 8 digit hex codes