### PR TITLE
Add manifest.json files for each sim with generator script

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,12 @@ Fetch the data by retrieving the url:
 * `{simId}` is the lowercase Simhub game id `DataCorePlugin.CurrentGame`
 * `{carId}` is the lowercase Simhub car id `DataCorePlugin.CarId`
 
+### Manifest Files
+Each sim folder contains a `manifest.json` listing all available cars:
+`/data/{simId}/manifest.json`
+
+See [scripts/MANIFEST_GENERATOR.md](scripts/MANIFEST_GENERATOR.md) for details on regenerating manifests.
+
 ## Changelog
 Read the [changelog](changelog.md) to keep track of the format updates.
 

--- a/data/AssettoCorsa/manifest.json
+++ b/data/AssettoCorsa/manifest.json
@@ -1,0 +1,9 @@
+{
+  "cars": [
+    {
+      "carName": "RSS Formula Hybrid 2023",
+      "carId": "rss_formula_hybrid_2023_AC",
+      "path": "rss_formula_hybrid_2023.json"
+    }
+  ]
+}

--- a/data/AssettoCorsaCompetizione/manifest.json
+++ b/data/AssettoCorsaCompetizione/manifest.json
@@ -1,0 +1,269 @@
+{
+  "cars": [
+    {
+      "carName": "Alpine A110 GT4",
+      "carId": "alpine_a110_gt4",
+      "path": "alpine_a110_gt4.json"
+    },
+    {
+      "carName": "AMR Vantage V12 GT3",
+      "carId": "amr_v12_vantage_gt3",
+      "path": "amr_v12_vantage_gt3.json"
+    },
+    {
+      "carName": "AMR Vantage V8 GT3",
+      "carId": "amr_v8_vantage_gt3",
+      "path": "amr_v8_vantage_gt3.json"
+    },
+    {
+      "carName": "AMR Vantage V8 GT4",
+      "carId": "amr_v8_vantage_gt4",
+      "path": "amr_v8_vantage_gt4.json"
+    },
+    {
+      "carName": "Audi R8 GT4",
+      "carId": "audi_r8_gt4",
+      "path": "audi_r8_gt4.json"
+    },
+    {
+      "carName": "Audi R8 LMS",
+      "carId": "audi_r8_lms",
+      "path": "audi_r8_lms.json"
+    },
+    {
+      "carName": "Audi R8 LMS EVO",
+      "carId": "audi_r8_lms_evo",
+      "path": "audi_r8_lms_evo.json"
+    },
+    {
+      "carName": "Audi R8 LMS EVOii",
+      "carId": "audi_r8_lms_evo_ii",
+      "path": "audi_r8_lms_evo_ii.json"
+    },
+    {
+      "carName": "AUDI R8 LMS GT2 2021",
+      "carId": "audi_r8_lms_gt2",
+      "path": "audi_r8_lms_gt2.json"
+    },
+    {
+      "carName": "Bentley Continental GT3 2016",
+      "carId": "bentley_continental_gt3_2016",
+      "path": "bentley_continental_gt3_2016.json"
+    },
+    {
+      "carName": "Bentley Continental GT3 2018",
+      "carId": "bentley_continental_gt3_2018",
+      "path": "bentley_continental_gt3_2018.json"
+    },
+    {
+      "carName": "BMW m2 CUP 2020",
+      "carId": "bmw_m2_cs_racing",
+      "path": "bmw_m2_cs_racing.json"
+    },
+    {
+      "carName": "BMW M4 GT3",
+      "carId": "bmw_m4_gt3",
+      "path": "bmw_m4_gt3.json"
+    },
+    {
+      "carName": "BMW M4 GT4",
+      "carId": "bmw_m4_gt4",
+      "path": "bmw_m4_gt4.json"
+    },
+    {
+      "carName": "BMW M6 GT3",
+      "carId": "bmw_m6_gt3",
+      "path": "bmw_m6_gt3.json"
+    },
+    {
+      "carName": "Chevrolet Camaro GT4R",
+      "carId": "chevrolet_camaro_gt4r",
+      "path": "chevrolet_camaro_gt4r.json"
+    },
+    {
+      "carName": "Ferrari 296 GT3",
+      "carId": "ferrari_296_gt3",
+      "path": "ferrari_296_gt3.json"
+    },
+    {
+      "carName": "FERRARI 488 CHALLENGE EVO 2020",
+      "carId": "ferrari_488_challenge_evo",
+      "path": "ferrari_488_challenge_evo.json"
+    },
+    {
+      "carName": "Ferrari 488 GT3",
+      "carId": "ferrari_488_gt3",
+      "path": "ferrari_488_gt3.json"
+    },
+    {
+      "carName": "Ferrari 488 EVO GT3",
+      "carId": "ferrari_488_gt3_evo",
+      "path": "ferrari_488_gt3_evo.json"
+    },
+    {
+      "carName": "Ford Mustang GT3",
+      "carId": "ford_mustang_gt3",
+      "path": "ford_mustang_gt3.json"
+    },
+    {
+      "carName": "Honda NSX GT3",
+      "carId": "honda_nsx_gt3",
+      "path": "honda_nsx_gt3.json"
+    },
+    {
+      "carName": "Honda NSX Evo GT3",
+      "carId": "honda_nsx_gt3_evo",
+      "path": "honda_nsx_gt3_evo.json"
+    },
+    {
+      "carName": "Jaguar G3",
+      "carId": "jaguar_g3",
+      "path": "jaguar_g3.json"
+    },
+    {
+      "carName": "",
+      "carId": "ktm_xbow_gt2",
+      "path": "ktm_xbow_gt2.json"
+    },
+    {
+      "carName": "KTM X-Bow GT4",
+      "carId": "ktm_xbow_gt4",
+      "path": "ktm_xbow_gt4.json"
+    },
+    {
+      "carName": "Lamborghini Gallardo REX",
+      "carId": "lamborghini_gallardo_rex",
+      "path": "lamborghini_gallardo_rex.json"
+    },
+    {
+      "carName": "Lamborghini Huracan GT3",
+      "carId": "lamborghini_huracan_gt3",
+      "path": "lamborghini_huracan_gt3.json"
+    },
+    {
+      "carName": "Lamborghini Huracan EVO GT3",
+      "carId": "lamborghini_huracan_gt3_evo",
+      "path": "lamborghini_huracan_gt3_evo.json"
+    },
+    {
+      "carName": "Lamborghini Huracan EVO2 GT3",
+      "carId": "lamborghini_huracan_gt3_evo2",
+      "path": "lamborghini_huracan_gt3_evo2.json"
+    },
+    {
+      "carName": "LAMBORGHINI HURACÁN ST 2015",
+      "carId": "lamborghini_huracan_st",
+      "path": "lamborghini_huracan_st.json"
+    },
+    {
+      "carName": "LAMBORGHINI HURACÁN ST EVO2 2021",
+      "carId": "lamborghini_huracan_st_evo2",
+      "path": "lamborghini_huracan_st_evo2.json"
+    },
+    {
+      "carName": "Lexus RC-F GT3",
+      "carId": "lexus_rc_f_gt3",
+      "path": "lexus_rc_f_gt3.json"
+    },
+    {
+      "carName": "MASERATI GT2 2023",
+      "carId": "maserati_mc20_gt2",
+      "path": "maserati_mc20_gt2.json"
+    },
+    {
+      "carName": "Maserati MC GT4",
+      "carId": "maserati_mc_gt4",
+      "path": "maserati_mc_gt4.json"
+    },
+    {
+      "carName": "McLaren 570S GT4",
+      "carId": "mclaren_570s_gt4",
+      "path": "mclaren_570s_gt4.json"
+    },
+    {
+      "carName": "McLaren 650S GT3",
+      "carId": "mclaren_650s_gt3",
+      "path": "mclaren_650s_gt3.json"
+    },
+    {
+      "carName": "McLaren 720S GT3",
+      "carId": "mclaren_720s_gt3",
+      "path": "mclaren_720s_gt3.json"
+    },
+    {
+      "carName": "McLaren 720S GT3 EVO",
+      "carId": "mclaren_720s_gt3_evo",
+      "path": "mclaren_720s_gt3_evo.json"
+    },
+    {
+      "carName": "",
+      "carId": "mercedes_amg_gt2",
+      "path": "mercedes_amg_gt2.json"
+    },
+    {
+      "carName": "Mercedes AMG GT3",
+      "carId": "mercedes_amg_gt3",
+      "path": "mercedes_amg_gt3.json"
+    },
+    {
+      "carName": "Mercedes AMG GT3 EVO",
+      "carId": "mercedes_amg_gt3_evo",
+      "path": "mercedes_amg_gt3_evo.json"
+    },
+    {
+      "carName": "Mercedes AMG GT4",
+      "carId": "mercedes_amg_gt4",
+      "path": "mercedes_amg_gt4.json"
+    },
+    {
+      "carName": "Nissan GT-R GT3 2017",
+      "carId": "nissan_gt_r_gt3_2017",
+      "path": "nissan_gt_r_gt3_2017.json"
+    },
+    {
+      "carName": "Nissan GT-R GT3 2018",
+      "carId": "nissan_gt_r_gt3_2018",
+      "path": "nissan_gt_r_gt3_2018.json"
+    },
+    {
+      "carName": "Porsche 718 Cayman GT4",
+      "carId": "porsche_718_cayman_gt4_mr",
+      "path": "porsche_718_cayman_gt4_mr.json"
+    },
+    {
+      "carName": "PORSCHE 935 2019",
+      "carId": "porsche_935",
+      "path": "porsche_935.json"
+    },
+    {
+      "carName": "PORSCHE 991 II GT2 RS CS EVO 2023",
+      "carId": "porsche_991_gt2_rs_mr",
+      "path": "porsche_991_gt2_rs_mr.json"
+    },
+    {
+      "carName": "Porsche 991 GT3R",
+      "carId": "porsche_991_gt3_r",
+      "path": "porsche_991_gt3_r.json"
+    },
+    {
+      "carName": "Porsche 991ii Cup",
+      "carId": "porsche_991ii_gt3_cup",
+      "path": "porsche_991ii_gt3_cup.json"
+    },
+    {
+      "carName": "Porsche 991ii GT3R",
+      "carId": "porsche_991ii_gt3_r",
+      "path": "porsche_991ii_gt3_r.json"
+    },
+    {
+      "carName": "Porsche 992 Cup",
+      "carId": "porsche_992_gt3_cup",
+      "path": "porsche_992_gt3_cup.json"
+    },
+    {
+      "carName": "Porsche 992 GT3R",
+      "carId": "porsche_992_gt3_r",
+      "path": "porsche_992_gt3_r.json"
+    }
+  ]
+}

--- a/data/Automobilista2/manifest.json
+++ b/data/Automobilista2/manifest.json
@@ -1,0 +1,569 @@
+{
+  "cars": [
+    {
+      "carName": "Alpine A424",
+      "carId": "Alpine A424",
+      "path": "Alpine A424.json"
+    },
+    {
+      "carName": "Audi R8 LMS GT3 evo II",
+      "carId": "Audi R8 LMS GT3 evo II",
+      "path": "Audi R8 LMS GT3 evo II.json"
+    },
+    {
+      "carName": "Audi R8 LMS GT4",
+      "carId": "Audi R8 LMS GT4",
+      "path": "Audi R8 LMS GT4.json"
+    },
+    {
+      "carName": "BMW M Hybrid V8",
+      "carId": "BMW M Hybrid V8",
+      "path": "BMW M Hybrid V8.json"
+    },
+    {
+      "carName": "BMW M4 GT3",
+      "carId": "BMW M4 GT3",
+      "path": "BMW M4 GT3.json"
+    },
+    {
+      "carName": "BMW M4 GT4",
+      "carId": "BMW M4 GT4",
+      "path": "BMW M4 GT4.json"
+    },
+    {
+      "carName": "Cadillac V-Series.R",
+      "carId": "Cadillac V-Series.R",
+      "path": "Cadillac V-Series.R.json"
+    },
+    {
+      "carName": "Chevrolet Camaro GT4.R",
+      "carId": "Chevrolet Camaro GT4.R",
+      "path": "Chevrolet Camaro GT4.R.json"
+    },
+    {
+      "carName": "Chevrolet Corvette Z06 GT3.R",
+      "carId": "Chevrolet Corvette Z06 GT3.R",
+      "path": "Chevrolet Corvette Z06 GT3.R.json"
+    },
+    {
+      "carName": "Chevrolet Cruze Stock Car 2020",
+      "carId": "Chevrolet Cruze Stock Car 2020",
+      "path": "Chevrolet Cruze Stock Car 2020.json"
+    },
+    {
+      "carName": "Chevrolet Cruze Stock Car 2021",
+      "carId": "Chevrolet Cruze Stock Car 2021",
+      "path": "Chevrolet Cruze Stock Car 2021.json"
+    },
+    {
+      "carName": "Chevrolet Cruze Stock Car 2022",
+      "carId": "Chevrolet Cruze Stock Car 2022",
+      "path": "Chevrolet Cruze Stock Car 2022.json"
+    },
+    {
+      "carName": "Chevrolet Cruze Stock Car 2023",
+      "carId": "Chevrolet Cruze Stock Car 2023",
+      "path": "Chevrolet Cruze Stock Car 2023.json"
+    },
+    {
+      "carName": "Chevrolet Cruze Stock Car 2024",
+      "carId": "Chevrolet Cruze Stock Car 2024",
+      "path": "Chevrolet Cruze Stock Car 2024.json"
+    },
+    {
+      "carName": "Dallara F301",
+      "carId": "Dallara F301",
+      "path": "Dallara F301.json"
+    },
+    {
+      "carName": "Dallara F309",
+      "carId": "Dallara F309",
+      "path": "Dallara F309.json"
+    },
+    {
+      "carName": "Formula Inter MG-15",
+      "carId": "Formula Inter MG-15",
+      "path": "Formula Inter MG-15.json"
+    },
+    {
+      "carName": "Formula Reiza",
+      "carId": "Formula Reiza",
+      "path": "Formula Reiza.json"
+    },
+    {
+      "carName": "Formula Ultimate Gen1",
+      "carId": "Formula Ultimate Gen1",
+      "path": "Formula Ultimate Gen1.json"
+    },
+    {
+      "carName": "Formula Ultimate Gen2",
+      "carId": "Formula Ultimate Gen2",
+      "path": "Formula Ultimate Gen2.json"
+    },
+    {
+      "carName": "Formula Ultimate Hybrid Gen2 - Low Downforce",
+      "carId": "Formula Ultimate Hybrid Gen2 - Low Downforce",
+      "path": "Formula Ultimate Hybrid Gen2 - Low Downforce.json"
+    },
+    {
+      "carName": "Formula Ultimate Hybrid Gen2",
+      "carId": "Formula Ultimate Hybrid Gen2",
+      "path": "Formula Ultimate Hybrid Gen2.json"
+    },
+    {
+      "carName": "Formula Ultimate Hybrid Gen3 - Low Downforce",
+      "carId": "Formula Ultimate Hybrid Gen3 - Low Downforce",
+      "path": "Formula Ultimate Hybrid Gen3 - Low Downforce.json"
+    },
+    {
+      "carName": "Formula Ultimate Hybrid Gen3",
+      "carId": "Formula Ultimate Hybrid Gen3",
+      "path": "Formula Ultimate Hybrid Gen3.json"
+    },
+    {
+      "carName": "Formula V10 Gen2 - Low Downforce",
+      "carId": "Formula V10 Gen2 - Low Downforce",
+      "path": "Formula V10 Gen2 - Low Downforce.json"
+    },
+    {
+      "carName": "Formula V10 Gen2",
+      "carId": "Formula V10 Gen2",
+      "path": "Formula V10 Gen2.json"
+    },
+    {
+      "carName": "Formula V8 Gen3 - Low Downforce",
+      "carId": "Formula V8 Gen3 - Low Downforce",
+      "path": "Formula V8 Gen3 - Low Downforce.json"
+    },
+    {
+      "carName": "Formula V8 Gen3",
+      "carId": "Formula V8 Gen3",
+      "path": "Formula V8 Gen3.json"
+    },
+    {
+      "carName": "Ginetta G55 GT3",
+      "carId": "Ginetta G55 GT3",
+      "path": "Ginetta G55 GT3.json"
+    },
+    {
+      "carName": "Ginetta G55 GT4 Supercup",
+      "carId": "Ginetta G55 GT4 Supercup",
+      "path": "Ginetta G55 GT4 Supercup.json"
+    },
+    {
+      "carName": "Ginetta G55 GT4",
+      "carId": "Ginetta G55 GT4",
+      "path": "Ginetta G55 GT4.json"
+    },
+    {
+      "carName": "Lamborghini Huracan GT3 EVO2",
+      "carId": "Lamborghini Huracan GT3 EVO2",
+      "path": "Lamborghini Huracan GT3 EVO2.json"
+    },
+    {
+      "carName": "Lamborghini SC63",
+      "carId": "Lamborghini SC63",
+      "path": "Lamborghini SC63.json"
+    },
+    {
+      "carName": "Ligier JS P217",
+      "carId": "Ligier JS P217",
+      "path": "Ligier JS P217.json"
+    },
+    {
+      "carName": "MINI Cooper JCW",
+      "carId": "MINI Cooper JCW",
+      "path": "MINI Cooper JCW.json"
+    },
+    {
+      "carName": "McLaren 570S GT4",
+      "carId": "McLaren 570S GT4",
+      "path": "McLaren 570S GT4.json"
+    },
+    {
+      "carName": "McLaren 720S GT3 Evo",
+      "carId": "McLaren 720S GT3 Evo",
+      "path": "McLaren 720S GT3 Evo.json"
+    },
+    {
+      "carName": "McLaren Mercedes MP4/12",
+      "carId": "McLaren Mercedes MP4/12",
+      "path": "McLaren Mercedes MP4-12.json"
+    },
+    {
+      "carName": "Mercedes-AMG GT3 Evo",
+      "carId": "Mercedes-AMG GT3 Evo",
+      "path": "Mercedes-AMG GT3 Evo.json"
+    },
+    {
+      "carName": "Mercedes-AMG GT4",
+      "carId": "Mercedes-AMG GT4",
+      "path": "Mercedes-AMG GT4.json"
+    },
+    {
+      "carName": "Oreca 07",
+      "carId": "Oreca 07",
+      "path": "Oreca 07.json"
+    },
+    {
+      "carName": "Porsche 911 GT3 Cup 3.8",
+      "carId": "Porsche 911 GT3 Cup 3.8",
+      "path": "Porsche 911 GT3 Cup 3.8.json"
+    },
+    {
+      "carName": "Porsche 911 GT3 Cup 4.0",
+      "carId": "Porsche 911 GT3 Cup 4.0",
+      "path": "Porsche 911 GT3 Cup 4.0.json"
+    },
+    {
+      "carName": "Porsche 963",
+      "carId": "Porsche 963",
+      "path": "Porsche 963.json"
+    },
+    {
+      "carName": "Porsche 992 GT3 R",
+      "carId": "Porsche 992 GT3 R",
+      "path": "Porsche 992 GT3 R.json"
+    },
+    {
+      "carName": "Toyota Corolla Stock Car 2020",
+      "carId": "Toyota Corolla Stock Car 2020",
+      "path": "Toyota Corolla Stock Car 2020.json"
+    },
+    {
+      "carName": "Toyota Corolla Stock Car 2021",
+      "carId": "Toyota Corolla Stock Car 2021",
+      "path": "Toyota Corolla Stock Car 2021.json"
+    },
+    {
+      "carName": "Toyota Corolla Stock Car 2022",
+      "carId": "Toyota Corolla Stock Car 2022",
+      "path": "Toyota Corolla Stock Car 2022.json"
+    },
+    {
+      "carName": "Toyota Corolla Stock Car 2023",
+      "carId": "Toyota Corolla Stock Car 2023",
+      "path": "Toyota Corolla Stock Car 2023.json"
+    },
+    {
+      "carName": "Toyota Corolla Stock Car 2024",
+      "carId": "Toyota Corolla Stock Car 2024",
+      "path": "Toyota Corolla Stock Car 2024.json"
+    },
+    {
+      "carName": "Alpine A110 GT4 evo",
+      "carId": "alpine_a110_gt4_evo",
+      "path": "alpine_a110_gt4_evo.json"
+    },
+    {
+      "carName": "Aston Martin Valkyrie Hypercar",
+      "carId": "aston_martin_valkyrie_hypercar",
+      "path": "aston_martin_valkyrie_hypercar.json"
+    },
+    {
+      "carName": "Aston Martin Vantage GT3 Evo",
+      "carId": "aston_martin_vantage_gt3_evo",
+      "path": "aston_martin_vantage_gt3_evo.json"
+    },
+    {
+      "carName": "Aston Martin Vantage GT4 Evo",
+      "carId": "aston_martin_vantage_gt4_evo",
+      "path": "aston_martin_vantage_gt4_evo.json"
+    },
+    {
+      "carName": "Aston Martin Vantage GTE",
+      "carId": "aston_martin_vantage_gte",
+      "path": "aston_martin_vantage_gte.json"
+    },
+    {
+      "carName": "BMW M6 GT3",
+      "carId": "bmw_m6_gt3",
+      "path": "bmw_m6_gt3.json"
+    },
+    {
+      "carName": "BMW M8 GTE",
+      "carId": "bmw_m8_gte",
+      "path": "bmw_m8_gte.json"
+    },
+    {
+      "carName": "Cadillac dpi-vr",
+      "carId": "cadillac_dpi-vr",
+      "path": "cadillac_dpi_vr.json"
+    },
+    {
+      "carName": "Caterham supersport",
+      "carId": "caterham_supersport",
+      "path": "caterham_supersport.json"
+    },
+    {
+      "carName": "Chevrolet Corvette C8.R",
+      "carId": "chevrolet_corvette_c8.r",
+      "path": "chevrolet_corvette_c8r.json"
+    },
+    {
+      "carName": "Citroen DS3 RX",
+      "carId": "citroen_ds3_rx",
+      "path": "citroen_ds3_rx.json"
+    },
+    {
+      "carName": "Copa Montana",
+      "carId": "copa_montana",
+      "path": "copa_montana.json"
+    },
+    {
+      "carName": "Formula Dirt",
+      "carId": "formula_dirt",
+      "path": "formula_dirt.json"
+    },
+    {
+      "carName": "Formula Trainer Advanced",
+      "carId": "formula_trainer_advanced",
+      "path": "formula_trainer_advanced.json"
+    },
+    {
+      "carName": "Formula USA 2023",
+      "carId": "formula_usa_2023",
+      "path": "formula_usa_2023.json"
+    },
+    {
+      "carName": "Formula V10 gen2",
+      "carId": "formula_v10_gen2",
+      "path": "formula_v10_gen2.json"
+    },
+    {
+      "carName": "Ginetta G40",
+      "carId": "ginetta_g40",
+      "path": "ginetta_g40.json"
+    },
+    {
+      "carName": "Ginetta G40 Cup",
+      "carId": "ginetta_g40_cup",
+      "path": "ginetta_g40_cup.json"
+    },
+    {
+      "carName": "Ginetta G58",
+      "carId": "ginetta_g58",
+      "path": "ginetta_g58.json"
+    },
+    {
+      "carName": "Ginetta G58 Gen2",
+      "carId": "ginetta_g58_gen2",
+      "path": "ginetta_g58_gen2.json"
+    },
+    {
+      "carName": "Iveco Stralis",
+      "carId": "iveco_stralis",
+      "path": "iveco_stralis.json"
+    },
+    {
+      "carName": "Kart 2-Stroke 125CC Shifter",
+      "carId": "kart_2-stroke_125cc_shifter",
+      "path": "karting_2-stroke_125cc_shifter.json"
+    },
+    {
+      "carName": "Kart Cross",
+      "carId": "kart_cross",
+      "path": "karting_cross.json"
+    },
+    {
+      "carName": "Lamborghini Huracan Super Trofeo Evo2",
+      "carId": "lamborghini_huracan_super_trofeo_evo2",
+      "path": "lamborghini_huracan_super_trofeo_evo2.json"
+    },
+    {
+      "carName": "Lamborghini SC63",
+      "carId": "lamborghini_sc63",
+      "path": "lamborghini_sc63.json"
+    },
+    {
+      "carName": "Ligier JS2 R",
+      "carId": "ligier_js2_r",
+      "path": "ligier_js2_r.json"
+    },
+    {
+      "carName": "Ligier JS P320",
+      "carId": "ligier_js_p320",
+      "path": "ligier_js_p320.json"
+    },
+    {
+      "carName": "Lola B2K00 Ford-Cosworth",
+      "carId": "lola_b2k00_ford-cosworth",
+      "path": "lola_b2k00_ford-cosworth.json"
+    },
+    {
+      "carName": "Lola B2K00 Mercedes-Benz",
+      "carId": "lola_b2k00_mercedes-benz",
+      "path": "lola_b2k00_mercedes-benz.json"
+    },
+    {
+      "carName": "Lola B2K00 Toyota",
+      "carId": "lola_b2k00_toyota",
+      "path": "lola_b2k00_toyota.json"
+    },
+    {
+      "carName": "MAN TGX",
+      "carId": "man_tgx",
+      "path": "man_tgx.json"
+    },
+    {
+      "carName": "McLaren F1 GTR",
+      "carId": "mclaren_f1_gtr",
+      "path": "mclaren_f1_gtr.json"
+    },
+    {
+      "carName": "McLaren Mercedes MP4/12",
+      "carId": "mclaren_mercedes_mp4/12",
+      "path": "mclaren_mercedes_mp4-12.json"
+    },
+    {
+      "carName": "MCR S2000",
+      "carId": "mcr_s2000",
+      "path": "mcr_s2000.json"
+    },
+    {
+      "carName": "Mercedes-Benz Actros",
+      "carId": "mercedes-benz_actros",
+      "path": "mercedes-benz_actros.json"
+    },
+    {
+      "carName": "Metalmoro AJR Chevrolet",
+      "carId": "metalmoro_ajr_chevrolet",
+      "path": "metalmoro_ajr_chevrolet.json"
+    },
+    {
+      "carName": "Metalmoro AJR Gen2 Chevrolet",
+      "carId": "metalmoro_ajr_gen2_chevrolet",
+      "path": "metalmoro_ajr_gen2_chevrolet.json"
+    },
+    {
+      "carName": "Metalmoro AJR Gen2 Honda",
+      "carId": "metalmoro_ajr_gen2_honda",
+      "path": "metalmoro_ajr_gen2_honda.json"
+    },
+    {
+      "carName": "Metalmoro AJR Gen2 Nissan",
+      "carId": "metalmoro_ajr_gen2_nissan",
+      "path": "metalmoro_ajr_gen2_nissan.json"
+    },
+    {
+      "carName": "Metalmoro AJR Honda",
+      "carId": "metalmoro_ajr_honda",
+      "path": "metalmoro_ajr_honda.json"
+    },
+    {
+      "carName": "Metalmoro AJR Nissan",
+      "carId": "metalmoro_ajr_nissan",
+      "path": "metalmoro_ajr_nissan.json"
+    },
+    {
+      "carName": "Metalmoro MRX Duratec Turbo P2",
+      "carId": "metalmoro_mrx_duratec_turbo_p2",
+      "path": "metalmoro_mrx_duratec_turbo_p2.json"
+    },
+    {
+      "carName": "Metalmoro MRX Duratec Turbo P3",
+      "carId": "metalmoro_mrx_duratec_turbo_p3",
+      "path": "metalmoro_mrx_duratec_turbo_p3.json"
+    },
+    {
+      "carName": "Metalmoro MRX Honda P3",
+      "carId": "metalmoro_mrx_honda_p3",
+      "path": "metalmoro_mrx_honda_p3.json"
+    },
+    {
+      "carName": "Mitsubishi Lancer Evo10 RX",
+      "carId": "mitsubishi_lancer_evo10_rx",
+      "path": "mitsubishi_lancer_evo10_rx.json"
+    },
+    {
+      "carName": "Mitsubishi Lancer R",
+      "carId": "mitsubishi_lancer_r",
+      "path": "mitsubishi_lancer_r.json"
+    },
+    {
+      "carName": "Mitsubishi Lancer RS",
+      "carId": "mitsubishi_lancer_rs",
+      "path": "mitsubishi_lancer_rs.json"
+    },
+    {
+      "carName": "Nissan GT-R Nismo GT3",
+      "carId": "nissan_gtr_nismo_gt3",
+      "path": "nissan_gtr_nismo_gt3.json"
+    },
+    {
+      "carName": "Porsche 911 GT3 R",
+      "carId": "porsche_911_gt3_r",
+      "path": "porsche_911_gt3_r.json"
+    },
+    {
+      "carName": "Porsche 911 RSR GTE",
+      "carId": "porsche_911_rsr_gte",
+      "path": "porsche_911_rsr_gte.json"
+    },
+    {
+      "carName": "Reynard 2KI Ford-Cosworth",
+      "carId": "reynard_2ki_ford-cosworth",
+      "path": "reynard_2ki_ford-cosworth.json"
+    },
+    {
+      "carName": "Reynard 2KI Honda",
+      "carId": "reynard_2ki_Honda",
+      "path": "reynard_2ki_honda.json"
+    },
+    {
+      "carName": "Reynard 2KI Mercedes-Benz",
+      "carId": "reynard_2ki_Mercedes-Benz",
+      "path": "reynard_2ki_mercedes-benz.json"
+    },
+    {
+      "carName": "Reynard 2KI Toyota",
+      "carId": "reynard_2ki_toyota",
+      "path": "reynard_2ki_toyota.json"
+    },
+    {
+      "carName": "Roco 001",
+      "carId": "roco 001",
+      "path": "roco_001.json"
+    },
+    {
+      "carName": "Sigma P1",
+      "carId": "sigma_p1",
+      "path": "sigma_p1.json"
+    },
+    {
+      "carName": "Sigma P1 G5",
+      "carId": "sigma_p1_g5",
+      "path": "sigma_p1_g5.json"
+    },
+    {
+      "carName": "Sprint Race",
+      "carId": "sprint_race",
+      "path": "sprint_race.json"
+    },
+    {
+      "carName": "Super Trophy Trucks",
+      "carId": "super_trophy_trucks",
+      "path": "super_trophy_trucks.json"
+    },
+    {
+      "carName": "Superkart 250cc",
+      "carId": "superkart_250cc",
+      "path": "superkart_250cc.json"
+    },
+    {
+      "carName": "Swift 009c Ford-Cosworth",
+      "carId": "swift_009c_ford-cosworth",
+      "path": "swift_009c_ford-cosworth.json"
+    },
+    {
+      "carName": "Volkswagen Constellation",
+      "carId": "volkswagen_constellation",
+      "path": "volkswagen_constellation.json"
+    },
+    {
+      "carName": "Vulkan Truck",
+      "carId": "vulkan_truck",
+      "path": "vulkan_truck.json"
+    }
+  ]
+}

--- a/data/F12024/manifest.json
+++ b/data/F12024/manifest.json
@@ -1,0 +1,179 @@
+{
+  "cars": [
+    {
+      "carName": "AIX Racing 24",
+      "carId": "AIX Racing 24",
+      "path": "AIX Racing 24.json"
+    },
+    {
+      "carName": "ART Grand Prix 24",
+      "carId": "ART Grand Prix 24",
+      "path": "ART Grand Prix 24.json"
+    },
+    {
+      "carName": "Alpha Tauri",
+      "carId": "Alpha Tauri",
+      "path": "Alpha Tauri.json"
+    },
+    {
+      "carName": "Alpine",
+      "carId": "Alpine",
+      "path": "Alpine.json"
+    },
+    {
+      "carName": "Art GP ‘23",
+      "carId": "Art GP ‘23",
+      "path": "Art GP ‘23.json"
+    },
+    {
+      "carName": "Aston Martin",
+      "carId": "Aston Martin",
+      "path": "Aston Martin.json"
+    },
+    {
+      "carName": "Campos Racing 24",
+      "carId": "Campos Racing 24",
+      "path": "Campos Racing 24.json"
+    },
+    {
+      "carName": "Campos ‘23",
+      "carId": "Campos ‘23",
+      "path": "Campos ‘23.json"
+    },
+    {
+      "carName": "Carlin ‘23",
+      "carId": "Carlin ‘23",
+      "path": "Carlin ‘23.json"
+    },
+    {
+      "carName": "DAMS 24",
+      "carId": "DAMS 24",
+      "path": "DAMS 24.json"
+    },
+    {
+      "carName": "Dams ‘23",
+      "carId": "Dams ‘23",
+      "path": "Dams ‘23.json"
+    },
+    {
+      "carName": "F1 Custom Team",
+      "carId": "F1 Custom Team",
+      "path": "F1 Custom Team.json"
+    },
+    {
+      "carName": "F1 Generic",
+      "carId": "F1 Generic",
+      "path": "F1 Generic.json"
+    },
+    {
+      "carName": "Ferrari",
+      "carId": "Ferrari",
+      "path": "Ferrari.json"
+    },
+    {
+      "carName": "Haas",
+      "carId": "Haas",
+      "path": "Haas.json"
+    },
+    {
+      "carName": "Hitech Grand Prix 24",
+      "carId": "Hitech Grand Prix 24",
+      "path": "Hitech Grand Prix 24.json"
+    },
+    {
+      "carName": "Hitech ‘23",
+      "carId": "Hitech ‘23",
+      "path": "Hitech ‘23.json"
+    },
+    {
+      "carName": "Invicta 24",
+      "carId": "Invicta 24",
+      "path": "Invicta 24.json"
+    },
+    {
+      "carName": "MP Motorsport 24",
+      "carId": "MP Motorsport 24",
+      "path": "MP Motorsport 24.json"
+    },
+    {
+      "carName": "MP Motorsport ‘23",
+      "carId": "MP Motorsport ‘23",
+      "path": "MP Motorsport ‘23.json"
+    },
+    {
+      "carName": "McLaren",
+      "carId": "McLaren",
+      "path": "McLaren.json"
+    },
+    {
+      "carName": "Mercedes",
+      "carId": "Mercedes",
+      "path": "Mercedes.json"
+    },
+    {
+      "carName": "PHM ‘23",
+      "carId": "PHM ‘23",
+      "path": "PHM ‘23.json"
+    },
+    {
+      "carName": "Prema Racing 24",
+      "carId": "Prema Racing 24",
+      "path": "Prema Racing 24.json"
+    },
+    {
+      "carName": "Prema ‘23",
+      "carId": "Prema ‘23",
+      "path": "Prema ‘23.json"
+    },
+    {
+      "carName": "RB",
+      "carId": "RB",
+      "path": "RB.json"
+    },
+    {
+      "carName": "Red Bull Racing",
+      "carId": "Red Bull Racing",
+      "path": "Red Bull Racing.json"
+    },
+    {
+      "carName": "Rodin 24",
+      "carId": "Rodin 24",
+      "path": "Rodin 24.json"
+    },
+    {
+      "carName": "Sauber",
+      "carId": "Sauber",
+      "path": "Sauber.json"
+    },
+    {
+      "carName": "Trident 24",
+      "carId": "Trident 24",
+      "path": "Trident 24.json"
+    },
+    {
+      "carName": "Trident ‘23",
+      "carId": "Trident ‘23",
+      "path": "Trident ‘23.json"
+    },
+    {
+      "carName": "Van Amersfoort Racing 24",
+      "carId": "Van Amersfoort Racing 24",
+      "path": "Van Amersfoort Racing 24.json"
+    },
+    {
+      "carName": "Van Amersfoort Racing ‘23",
+      "carId": "Van Amersfoort Racing ‘23",
+      "path": "Van Amersfoort Racing ‘23.json"
+    },
+    {
+      "carName": "Virtuosi ‘23",
+      "carId": "Virtuosi ‘23",
+      "path": "Virtuosi ‘23.json"
+    },
+    {
+      "carName": "Williams",
+      "carId": "Williams",
+      "path": "Williams.json"
+    }
+  ]
+}

--- a/data/F12025/manifest.json
+++ b/data/F12025/manifest.json
@@ -1,0 +1,124 @@
+{
+  "cars": [
+    {
+      "carName": "AIX Racing 24",
+      "carId": "AIX Racing 24",
+      "path": "AIX Racing 24.json"
+    },
+    {
+      "carName": "ART Grand Prix 24",
+      "carId": "ART Grand Prix 24",
+      "path": "ART Grand Prix 24.json"
+    },
+    {
+      "carName": "Alpha Tauri",
+      "carId": "Alpha Tauri",
+      "path": "Alpha Tauri.json"
+    },
+    {
+      "carName": "Alpine",
+      "carId": "Alpine",
+      "path": "Alpine.json"
+    },
+    {
+      "carName": "Aston Martin",
+      "carId": "Aston Martin",
+      "path": "Aston Martin.json"
+    },
+    {
+      "carName": "Campos Racing 24",
+      "carId": "Campos Racing 24",
+      "path": "Campos Racing 24.json"
+    },
+    {
+      "carName": "DAMS 24",
+      "carId": "DAMS 24",
+      "path": "DAMS 24.json"
+    },
+    {
+      "carName": "F1 Custom Team",
+      "carId": "F1 Custom Team",
+      "path": "F1 Custom Team.json"
+    },
+    {
+      "carName": "F1 Generic",
+      "carId": "F1 Generic",
+      "path": "F1 Generic.json"
+    },
+    {
+      "carName": "Ferrari",
+      "carId": "Ferrari",
+      "path": "Ferrari.json"
+    },
+    {
+      "carName": "Haas",
+      "carId": "Haas",
+      "path": "Haas.json"
+    },
+    {
+      "carName": "Hitech Grand Prix 24",
+      "carId": "Hitech Grand Prix 24",
+      "path": "Hitech Grand Prix 24.json"
+    },
+    {
+      "carName": "Invicta 24",
+      "carId": "Invicta 24",
+      "path": "Invicta 24.json"
+    },
+    {
+      "carName": "MP Motorsport 24",
+      "carId": "MP Motorsport 24",
+      "path": "MP Motorsport 24.json"
+    },
+    {
+      "carName": "McLaren",
+      "carId": "McLaren",
+      "path": "McLaren.json"
+    },
+    {
+      "carName": "Mercedes",
+      "carId": "Mercedes",
+      "path": "Mercedes.json"
+    },
+    {
+      "carName": "Prema Racing 24",
+      "carId": "Prema Racing 24",
+      "path": "Prema Racing 24.json"
+    },
+    {
+      "carName": "RB",
+      "carId": "RB",
+      "path": "RB.json"
+    },
+    {
+      "carName": "Red Bull Racing",
+      "carId": "Red Bull Racing",
+      "path": "Red Bull Racing.json"
+    },
+    {
+      "carName": "Rodin 24",
+      "carId": "Rodin 24",
+      "path": "Rodin 24.json"
+    },
+    {
+      "carName": "Sauber",
+      "carId": "Sauber",
+      "path": "Sauber.json"
+    },
+    {
+      "carName": "Trident 24",
+      "carId": "Trident 24",
+      "path": "Trident 24.json"
+    },
+    {
+      "carName": "Van Amersfoort Racing 24",
+      "carId": "Van Amersfoort Racing 24",
+      "path": "Van Amersfoort Racing 24.json"
+    },
+    {
+      "carName": "Williams",
+      "carId": "Williams",
+      "path": "Williams.json"
+    }
+  ]
+}

--- a/data/IRacing/manifest.json
+++ b/data/IRacing/manifest.json
@@ -1,0 +1,334 @@
+{
+  "cars": [
+    {
+      "carName": "Acura ARX-06 GTP ",
+      "carId": "acuraarx06gtp",
+      "path": "acuraarx06gtp.json"
+    },
+    {
+      "carName": "Acura NSX GT3 EVO22",
+      "carId": "acuransxevo22gt3",
+      "path": "acuransxevo22gt3.json"
+    },
+    {
+      "carName": "AM Vantage EVO GT3",
+      "carId": "amvantageevogt3",
+      "path": "amvantageevogt3.json"
+    },
+    {
+      "carName": "AM Vantage GT4",
+      "carId": "amvantagegt4",
+      "path": "amvantagegt4.json"
+    },
+    {
+      "carName": "Audi R18",
+      "carId": "audir18",
+      "path": "audir18.json"
+    },
+    {
+      "carName": "Audi R8 LMS EVO2",
+      "carId": "audir8lmsevo2gt3",
+      "path": "audir8lmsevo2gt3.json"
+    },
+    {
+      "carName": "Audi RS3 LMS",
+      "carId": "audirs3lms",
+      "path": "audirs3lms.json"
+    },
+    {
+      "carName": "BMW M Hybrid V8",
+      "carId": "bmwlmdh",
+      "path": "bmwlmdh.json"
+    },
+    {
+      "carName": "BMW M2 CSR",
+      "carId": "bmwm2csr",
+      "path": "bmwm2csr.json"
+    },
+    {
+      "carName": "BMW M4 EVO GT4",
+      "carId": "bmwm4evogt4",
+      "path": "bmwm4evogt4.json"
+    },
+    {
+      "carName": "BMW M4 GT3",
+      "carId": "bmwm4gt3",
+      "path": "bmwm4gt3.json"
+    },
+    {
+      "carName": "BMW M4 GT4",
+      "carId": "bmwm4gt4",
+      "path": "bmwm4gt4.json"
+    },
+    {
+      "carName": "BMW M8 GTE",
+      "carId": "bmwm8gte",
+      "path": "bmwm8gte.json"
+    },
+    {
+      "carName": "Corvette C8 GTE",
+      "carId": "c8rvettegte",
+      "path": "c8rvettegte.json"
+    },
+    {
+      "carName": "Cadillac CTS-V",
+      "carId": "cadillacctsvr",
+      "path": "cadillacctsvr.json"
+    },
+    {
+      "carName": "Cadillac V-Series GTP",
+      "carId": "cadillacvseriesrgtp",
+      "path": "cadillacvseriesrgtp.json"
+    },
+    {
+      "carName": "Corvette Z06 GT3",
+      "carId": "chevyvettez06rgt3",
+      "path": "chevyvettez06rgt3.json"
+    },
+    {
+      "carName": "Dallara DW12",
+      "carId": "dallaradw12",
+      "path": "dallaradw12.json"
+    },
+    {
+      "carName": "Dallara F3",
+      "carId": "dallaraf3",
+      "path": "dallaraf3.json"
+    },
+    {
+      "carName": "Dallara IL15 Indy NXT",
+      "carId": "dallarail15",
+      "path": "dallarail15.json"
+    },
+    {
+      "carName": "Dallara iR01",
+      "carId": "dallarair01",
+      "path": "dallarair01.json"
+    },
+    {
+      "carName": "Dallara iR18",
+      "carId": "dallarair18",
+      "path": "dallarair18.json"
+    },
+    {
+      "carName": "Dallara P217",
+      "carId": "dallarap217",
+      "path": "dallarap217.json"
+    },
+    {
+      "carName": "Ferrari 296 Challenge",
+      "carId": "ferrari296challenge",
+      "path": "ferrari296challenge.json"
+    },
+    {
+      "carName": "Ferrari 296 GT3",
+      "carId": "ferrari296gt3",
+      "path": "ferrari296gt3.json"
+    },
+    {
+      "carName": "Ferrari 488 GTE",
+      "carId": "ferrari488gte",
+      "path": "ferrari488gte.json"
+    },
+    {
+      "carName": "Ferrari 499P",
+      "carId": "ferrari499p",
+      "path": "ferrari499p.json"
+    },
+    {
+      "carName": "Ford GT GTE",
+      "carId": "fordgt2017",
+      "path": "fordgt2017.json"
+    },
+    {
+      "carName": "Ford Mustang GT3",
+      "carId": "fordmustanggt3",
+      "path": "fordmustanggt3.json"
+    },
+    {
+      "carName": "Ford Mustang GT4",
+      "carId": "fordmustanggt4",
+      "path": "fordmustanggt4.json"
+    },
+    {
+      "carName": "Formula iR04",
+      "carId": "formulair04",
+      "path": "formulair04.json"
+    },
+    {
+      "carName": "Formula Renault 2.0",
+      "carId": "formularenault20",
+      "path": "formularenault20.json"
+    },
+    {
+      "carName": "Formula Renault 3.5",
+      "carId": "formularenault35",
+      "path": "formularenault35.json"
+    },
+    {
+      "carName": "Honda Civic Type R",
+      "carId": "hondacivictyper",
+      "path": "hondacivictyper.json"
+    },
+    {
+      "carName": "HPX ARX-01C",
+      "carId": "hpdarx01c",
+      "path": "hpdarx01c.json"
+    },
+    {
+      "carName": "Hyundai Elantra N",
+      "carId": "hyundaielantracn7",
+      "path": "hyundaielantracn7.json"
+    },
+    {
+      "carName": "Hyundai Veloster N",
+      "carId": "hyundaivelostern",
+      "path": "hyundaivelostern.json"
+    },
+    {
+      "carName": "Lamborghini Huracán EVO GT3",
+      "carId": "lamborghinievogt3",
+      "path": "lamborghinievogt3.json"
+    },
+    {
+      "carName": "Ligier JS P320",
+      "carId": "ligierjsp320",
+      "path": "ligierjsp320.json"
+    },
+    {
+      "carName": "McLaren 570S GT4",
+      "carId": "mclaren570sgt4",
+      "path": "mclaren570sgt4.json"
+    },
+    {
+      "carName": "McLaren 720S GT3",
+      "carId": "mclaren720sgt3",
+      "path": "mclaren720sgt3.json"
+    },
+    {
+      "carName": "McLaren MP4-12C",
+      "carId": "mclarenmp4",
+      "path": "mclarenmp4.json"
+    },
+    {
+      "carName": "Mercedes AMG EVO GT3",
+      "carId": "mercedesamgevogt3",
+      "path": "mercedesamgevogt3.json"
+    },
+    {
+      "carName": "Mercedes AMG GT4",
+      "carId": "mercedesamggt4",
+      "path": "mercedesamggt4.json"
+    },
+    {
+      "carName": "Mercedes W12",
+      "carId": "mercedesw12",
+      "path": "mercedesw12.json"
+    },
+    {
+      "carName": "Mercedes W13",
+      "carId": "mercedesw13",
+      "path": "mercedesw13.json"
+    },
+    {
+      "carName": "Mazda MX-5 Cup",
+      "carId": "mx5 mx52016",
+      "path": "mx5 mx52016.json"
+    },
+    {
+      "carName": "Porsche 718 GT4",
+      "carId": "porsche718gt4",
+      "path": "porsche718gt4.json"
+    },
+    {
+      "carName": "Porsche 919",
+      "carId": "porsche919",
+      "path": "porsche919.json"
+    },
+    {
+      "carName": "Porsche 963",
+      "carId": "porsche963gtp",
+      "path": "porsche963gtp.json"
+    },
+    {
+      "carName": "Porsche 991RSR",
+      "carId": "porsche991rsr",
+      "path": "porsche991rsr.json"
+    },
+    {
+      "carName": "Porsche 911 Cup (992.2)",
+      "carId": "porsche9922cup",
+      "path": "porsche9922cup.json"
+    },
+    {
+      "carName": "Porsche 992 Cup",
+      "carId": "porsche992cup",
+      "path": "porsche992cup.json"
+    },
+    {
+      "carName": "Porsche 992R GT3",
+      "carId": "porsche992rgt3",
+      "path": "porsche992rgt3.json"
+    },
+    {
+      "carName": "Radical SR8",
+      "carId": "radical sr8",
+      "path": "radical sr8.json"
+    },
+    {
+      "carName": "Radical SR10",
+      "carId": "radicalsr10",
+      "path": "radicalsr10.json"
+    },
+    {
+      "carName": "Ray FF1600",
+      "carId": "raygr22",
+      "path": "raygr22.json"
+    },
+    {
+      "carName": "Renault Clio Cup",
+      "carId": "renaultcliocup",
+      "path": "renaultcliocup.json"
+    },
+    {
+      "carName": "SCCA Spec Racer Ford",
+      "carId": "specracer",
+      "path": "specracer.json"
+    },
+    {
+      "carName": "Chevrolet Camaro Gen3 Supercar",
+      "carId": "supercars chevycamarogen3",
+      "path": "supercars chevycamarogen3.json"
+    },
+    {
+      "carName": "Ford Mustang Gen3 Supercar",
+      "carId": "supercars fordmustanggen3",
+      "path": "supercars fordmustanggen3.json"
+    },
+    {
+      "carName": "Super Formula Lights",
+      "carId": "superformulalights324",
+      "path": "superformulalights324.json"
+    },
+    {
+      "carName": "Super Formula - Honda",
+      "carId": "superformulasf23 honda",
+      "path": "superformulasf23 honda.json"
+    },
+    {
+      "carName": "Super Formula - Toyota",
+      "carId": "superformulasf23 toyota",
+      "path": "superformulasf23 toyota.json"
+    },
+    {
+      "carName": "Toyota GR86",
+      "carId": "toyotagr86",
+      "path": "toyotagr86.json"
+    },
+    {
+      "carName": "USF2000",
+      "carId": "usf2000usf17",
+      "path": "usf2000usf17.json"
+    }
+  ]
+}

--- a/data/LMU/manifest.json
+++ b/data/LMU/manifest.json
@@ -1,0 +1,1134 @@
+{
+  "cars": [
+    {
+      "carName": "AF Corse 2024",
+      "carId": "AF Corse 2024",
+      "path": "AF Corse 2024.json"
+    },
+    {
+      "carName": "AF Corse GTE",
+      "carId": "AF Corse GTE",
+      "path": "AF Corse GTE.json"
+    },
+    {
+      "carName": "AF Corse",
+      "carId": "AF Corse",
+      "path": "AF Corse.json"
+    },
+    {
+      "carName": "AO by TF 2024",
+      "carId": "AO by TF 2024",
+      "path": "AO by TF 2024.json"
+    },
+    {
+      "carName": "Action Express Racing",
+      "carId": "Action Express Racing",
+      "path": "Action Express Racing.json"
+    },
+    {
+      "carName": "Algarve Pro Racing 2024",
+      "carId": "Algarve Pro Racing 2024",
+      "path": "Algarve Pro Racing 2024.json"
+    },
+    {
+      "carName": "Algarve Pro Racing",
+      "carId": "Algarve Pro Racing",
+      "path": "Algarve Pro Racing.json"
+    },
+    {
+      "carName": "Alpine Elf Team 2024",
+      "carId": "Alpine Elf Team 2024",
+      "path": "Alpine Elf Team 2024.json"
+    },
+    {
+      "carName": "Alpine Elf Team",
+      "carId": "Alpine Elf Team",
+      "path": "Alpine Elf Team.json"
+    },
+    {
+      "carName": "Alpine Endurance Team 2024",
+      "carId": "Alpine Endurance Team 2024",
+      "path": "Alpine Endurance Team 2024.json"
+    },
+    {
+      "carName": "BMW M Team WRT 2024",
+      "carId": "BMW M Team WRT 2024",
+      "path": "BMW M Team WRT 2024.json"
+    },
+    {
+      "carName": "Cadillac Racing 2024",
+      "carId": "Cadillac Racing 2024",
+      "path": "Cadillac Racing 2024.json"
+    },
+    {
+      "carName": "Cadillac Racing",
+      "carId": "Cadillac Racing",
+      "path": "Cadillac Racing.json"
+    },
+    {
+      "carName": "Cool Racing 2024",
+      "carId": "Cool Racing 2024",
+      "path": "Cool Racing 2024.json"
+    },
+    {
+      "carName": "Cool Racing",
+      "carId": "Cool Racing",
+      "path": "Cool Racing.json"
+    },
+    {
+      "carName": "Corvette Racing",
+      "carId": "Corvette Racing",
+      "path": "Corvette Racing.json"
+    },
+    {
+      "carName": "Crowdstrike Racing by APR 2024",
+      "carId": "Crowdstrike Racing by APR 2024",
+      "path": "Crowdstrike Racing by APR 2024.json"
+    },
+    {
+      "carName": "D'station Racing",
+      "carId": "D'station Racing",
+      "path": "D'station Racing.json"
+    },
+    {
+      "carName": "DKR Engineering 2024",
+      "carId": "DKR Engineering 2024",
+      "path": "DKR Engineering 2024.json"
+    },
+    {
+      "carName": "DKR Engineering",
+      "carId": "DKR Engineering",
+      "path": "DKR Engineering.json"
+    },
+    {
+      "carName": "Dempsey-Proton Racing",
+      "carId": "Dempsey-Proton Racing",
+      "path": "Dempsey-Proton Racing.json"
+    },
+    {
+      "carName": "Duqueine Team 2024",
+      "carId": "Duqueine Team 2024",
+      "path": "Duqueine Team 2024.json"
+    },
+    {
+      "carName": "Duqueine Team",
+      "carId": "Duqueine Team",
+      "path": "Duqueine Team.json"
+    },
+    {
+      "carName": "Ferrari AF Corse 2024",
+      "carId": "Ferrari AF Corse 2024",
+      "path": "Ferrari AF Corse 2024.json"
+    },
+    {
+      "carName": "Ferrari AF Corse",
+      "carId": "Ferrari AF Corse",
+      "path": "Ferrari AF Corse.json"
+    },
+    {
+      "carName": "Floyd Vanwall Racing Team",
+      "carId": "Floyd Vanwall Racing Team",
+      "path": "Floyd Vanwall Racing Team.json"
+    },
+    {
+      "carName": "GMB Motorsport",
+      "carId": "GMB Motorsport",
+      "path": "GMB Motorsport.json"
+    },
+    {
+      "carName": "GR Racing 2024",
+      "carId": "GR Racing 2024",
+      "path": "GR Racing 2024.json"
+    },
+    {
+      "carName": "GR Racing",
+      "carId": "GR Racing",
+      "path": "GR Racing.json"
+    },
+    {
+      "carName": "GT3_296GT3 Custom Team 2024",
+      "carId": "GT3_296GT3 Custom Team 2024",
+      "path": "GT3_296GT3 Custom Team 2024.json"
+    },
+    {
+      "carName": "GT3_296GT3 Custom Team 2025",
+      "carId": "GT3_296GT3 Custom Team 2025",
+      "path": "GT3_296GT3 Custom Team 2025.json"
+    },
+    {
+      "carName": "GT3_911GT3R Custom Team 2024",
+      "carId": "GT3_911GT3R Custom Team 2024",
+      "path": "GT3_911GT3R Custom Team 2024.json"
+    },
+    {
+      "carName": "GT3_911GT3R Custom Team 2025",
+      "carId": "GT3_911GT3R Custom Team 2025",
+      "path": "GT3_911GT3R Custom Team 2025.json"
+    },
+    {
+      "carName": "AF Corse 2025",
+      "carId": "GT3_AF Corse 2025",
+      "path": "GT3_AF Corse 2025.json"
+    },
+    {
+      "carName": "GT3_AMR GT3 Custom Team 2025",
+      "carId": "GT3_AMR GT3 Custom Team 2025",
+      "path": "GT3_AMR GT3 Custom Team 2025.json"
+    },
+    {
+      "carName": "GT3_AMR GT3 Custom Team",
+      "carId": "GT3_AMR GT3 Custom Team",
+      "path": "GT3_AMR GT3 Custom Team.json"
+    },
+    {
+      "carName": "GT3_AWA Racing 2025",
+      "carId": "GT3_AWA Racing 2025",
+      "path": "GT3_AWA Racing 2025.json"
+    },
+    {
+      "carName": "GT3_Akkodis ASP Team 2024",
+      "carId": "GT3_Akkodis ASP Team 2024",
+      "path": "GT3_Akkodis ASP Team 2024.json"
+    },
+    {
+      "carName": "GT3_Akkodis ASP Team 2025",
+      "carId": "GT3_Akkodis ASP Team 2025",
+      "path": "GT3_Akkodis ASP Team 2025.json"
+    },
+    {
+      "carName": "GT3_BMW GT3 Custom Team 2025",
+      "carId": "GT3_BMW GT3 Custom Team 2025",
+      "path": "GT3_BMW GT3 Custom Team 2025.json"
+    },
+    {
+      "carName": "GT3_BMW GT3 Custom Team",
+      "carId": "GT3_BMW GT3 Custom Team",
+      "path": "GT3_BMW GT3 Custom Team.json"
+    },
+    {
+      "carName": "GT3_D'Station Racing 2024",
+      "carId": "GT3_D'Station Racing 2024",
+      "path": "GT3_D'Station Racing 2024.json"
+    },
+    {
+      "carName": "GR Racing 2025",
+      "carId": "GT3_GR Racing 2025",
+      "path": "GT3_GR Racing 2025.json"
+    },
+    {
+      "carName": "GT3_Heart of Racing Team 2024",
+      "carId": "GT3_Heart of Racing Team 2024",
+      "path": "GT3_Heart of Racing Team 2024.json"
+    },
+    {
+      "carName": "GT3_Heart of Racing Team 2025",
+      "carId": "GT3_Heart of Racing Team 2025",
+      "path": "GT3_Heart of Racing Team 2025.json"
+    },
+    {
+      "carName": "GT3_Huracan Custom Team 2024",
+      "carId": "GT3_Huracan Custom Team 2024",
+      "path": "GT3_Huracan Custom Team 2024.json"
+    },
+    {
+      "carName": "GT3_Iron Dames 2024",
+      "carId": "GT3_Iron Dames 2024",
+      "path": "GT3_Iron Dames 2024.json"
+    },
+    {
+      "carName": "GT3_Iron Dames 2025",
+      "carId": "GT3_Iron Dames 2025",
+      "path": "GT3_Iron Dames 2025.json"
+    },
+    {
+      "carName": "GT3_Iron Lynx 2024",
+      "carId": "GT3_Iron Lynx 2024",
+      "path": "GT3_Iron Lynx 2024.json"
+    },
+    {
+      "carName": "Mercedes AMG LMGT3",
+      "carId": "GT3_Iron Lynx 2025",
+      "path": "GT3_Iron Lynx 2025.json"
+    },
+    {
+      "carName": "JMW Motorsport 2025",
+      "carId": "GT3_JMW Motorsport 2025",
+      "path": "GT3_JMW Motorsport 2025.json"
+    },
+    {
+      "carName": "GT3_Kessel Racing 2025",
+      "carId": "GT3_Kessel Racing 2025",
+      "path": "GT3_Kessel Racing 2025.json"
+    },
+    {
+      "carName": "GT3_Lexus Custom Team 2024",
+      "carId": "GT3_Lexus Custom Team 2024",
+      "path": "GT3_Lexus Custom Team 2024.json"
+    },
+    {
+      "carName": "GT3_Lexus Custom Team 2025",
+      "carId": "GT3_Lexus Custom Team 2025",
+      "path": "GT3_Lexus Custom Team 2025.json"
+    },
+    {
+      "carName": "GT3_Manthey 1st Phorm 2025",
+      "carId": "GT3_Manthey 1st Phorm 2025",
+      "path": "GT3_Manthey 1st Phorm 2025.json"
+    },
+    {
+      "carName": "GT3_Manthey 2025",
+      "carId": "GT3_Manthey 2025",
+      "path": "GT3_Manthey 2025.json"
+    },
+    {
+      "carName": "GT3_Manthey Ema 2024",
+      "carId": "GT3_Manthey Ema 2024",
+      "path": "GT3_Manthey Ema 2024.json"
+    },
+    {
+      "carName": "GT3_Manthey PureRxcing 2024",
+      "carId": "GT3_Manthey PureRxcing 2024",
+      "path": "GT3_Manthey PureRxcing 2024.json"
+    },
+    {
+      "carName": "GT3_McLaren Custom Team 2024",
+      "carId": "GT3_McLaren Custom Team 2024",
+      "path": "GT3_McLaren Custom Team 2024.json"
+    },
+    {
+      "carName": "GT3_McLaren Custom Team 2025",
+      "carId": "GT3_McLaren Custom Team 2025",
+      "path": "GT3_McLaren Custom Team 2025.json"
+    },
+    {
+      "carName": "Mercedes AMG LMGT3",
+      "carId": "GT3_Mercedes AMG Custom Team 2025",
+      "path": "GT3_Mercedes AMG Custom Team 2025.json"
+    },
+    {
+      "carName": "GT3_Mustang Custom Team 2024",
+      "carId": "GT3_Mustang Custom Team 2024",
+      "path": "GT3_Mustang Custom Team 2024.json"
+    },
+    {
+      "carName": "GT3_Mustang Custom Team 2025",
+      "carId": "GT3_Mustang Custom Team 2025",
+      "path": "GT3_Mustang Custom Team 2025.json"
+    },
+    {
+      "carName": "GT3_Proton Competition 2025",
+      "carId": "GT3_Proton Competition 2025",
+      "path": "GT3_Proton Competition 2025.json"
+    },
+    {
+      "carName": "GT3_Proton Racing 2024",
+      "carId": "GT3_Proton Racing 2024",
+      "path": "GT3_Proton Racing 2024.json"
+    },
+    {
+      "carName": "GT3_Racing Spirit of Léman 2025",
+      "carId": "GT3_Racing Spirit of Léman 2025",
+      "path": "GT3_Racing Spirit of Léman 2025.json"
+    },
+    {
+      "carName": "GT3_Richard Mille AF Corse 2025",
+      "carId": "GT3_Richard Mille AF Corse 2025",
+      "path": "GT3_Richard Mille AF Corse 2025.json"
+    },
+    {
+      "carName": "Spirit of Race 2025",
+      "carId": "GT3_Spirit of Race 2025",
+      "path": "GT3_Spirit of Race 2025.json"
+    },
+    {
+      "carName": "GT3_TF Sport 2025",
+      "carId": "GT3_TF Sport 2025",
+      "path": "GT3_TF Sport 2025.json"
+    },
+    {
+      "carName": "GT3_TF Sport",
+      "carId": "GT3_TF Sport",
+      "path": "GT3_TF Sport.json"
+    },
+    {
+      "carName": "GT3_Team WRT 2025",
+      "carId": "GT3_Team WRT 2025",
+      "path": "GT3_Team WRT 2025.json"
+    },
+    {
+      "carName": "GT3_The Bend Team WRT 2025",
+      "carId": "GT3_The Bend Team WRT 2025",
+      "path": "GT3_The Bend Team WRT 2025.json"
+    },
+    {
+      "carName": "GT3_United Autosports 2024",
+      "carId": "GT3_United Autosports 2024",
+      "path": "GT3_United Autosports 2024.json"
+    },
+    {
+      "carName": "GT3_United Autosports 2025",
+      "carId": "GT3_United Autosports 2025",
+      "path": "GT3_United Autosports 2025.json"
+    },
+    {
+      "carName": "GT3_Vista AF Corse 2025",
+      "carId": "GT3_Vista AF Corse 2025",
+      "path": "GT3_Vista AF Corse 2025.json"
+    },
+    {
+      "carName": "GT3_Z06GT3R Custom Team 2025",
+      "carId": "GT3_Z06GT3R Custom Team 2025",
+      "path": "GT3_Z06GT3R Custom Team 2025.json"
+    },
+    {
+      "carName": "GT3_Z06GT3R Custom Team",
+      "carId": "GT3_Z06GT3R Custom Team",
+      "path": "GT3_Z06GT3R Custom Team.json"
+    },
+    {
+      "carName": "GT3_Ziggo Sport Tempesta 2025",
+      "carId": "GT3_Ziggo Sport Tempesta 2025",
+      "path": "GT3_Ziggo Sport Tempesta 2025.json"
+    },
+    {
+      "carName": "GTE_488GTE Custom Team 2023",
+      "carId": "GTE_488GTE Custom Team 2023",
+      "path": "GTE_488GTE Custom Team 2023.json"
+    },
+    {
+      "carName": "GTE_911GTE Custom Team 2023",
+      "carId": "GTE_911GTE Custom Team 2023",
+      "path": "GTE_911GTE Custom Team 2023.json"
+    },
+    {
+      "carName": "GTE_AMV Custom Team 2023",
+      "carId": "GTE_AMV Custom Team 2023",
+      "path": "GTE_AMV Custom Team 2023.json"
+    },
+    {
+      "carName": "GTE_C8RGTE Custom Team 2023",
+      "carId": "GTE_C8RGTE Custom Team 2023",
+      "path": "GTE_C8RGTE Custom Team 2023.json"
+    },
+    {
+      "carName": "GTE_Northwest AMR",
+      "carId": "GTE_Northwest AMR",
+      "path": "GTE_Northwest AMR.json"
+    },
+    {
+      "carName": "Glickenhaus Racing",
+      "carId": "Glickenhaus Racing",
+      "path": "Glickenhaus Racing.json"
+    },
+    {
+      "carName": "Graff Racing 2024",
+      "carId": "Graff Racing 2024",
+      "path": "Graff Racing 2024.json"
+    },
+    {
+      "carName": "Graff Racing",
+      "carId": "Graff Racing",
+      "path": "Graff Racing.json"
+    },
+    {
+      "carName": "Hertz Team Jota 2024",
+      "carId": "Hertz Team Jota 2024",
+      "path": "Hertz Team Jota 2024.json"
+    },
+    {
+      "carName": "Hertz Team Jota",
+      "carId": "Hertz Team Jota",
+      "path": "Hertz Team Jota.json"
+    },
+    {
+      "carName": "Hyper_499P Custom Team 2023",
+      "carId": "Hyper_499P Custom Team 2023",
+      "path": "Hyper_499P Custom Team 2023.json"
+    },
+    {
+      "carName": "Hyper_499P Custom Team 2024",
+      "carId": "Hyper_499P Custom Team 2024",
+      "path": "Hyper_499P Custom Team 2024.json"
+    },
+    {
+      "carName": "Hyper_499P Custom Team 2025",
+      "carId": "Hyper_499P Custom Team 2025",
+      "path": "Hyper_499P Custom Team 2025.json"
+    },
+    {
+      "carName": "Hyper_9x8 Wing Custom Team 2024",
+      "carId": "Hyper_9x8 Wing Custom Team 2024",
+      "path": "Hyper_9x8 Wing Custom Team 2024.json"
+    },
+    {
+      "carName": "Hyper_9x8 Wing Custom Team 2025",
+      "carId": "Hyper_9x8 Wing Custom Team 2025",
+      "path": "Hyper_9x8 Wing Custom Team 2025.json"
+    },
+    {
+      "carName": "Hyper_AF Corse 2025",
+      "carId": "Hyper_AF Corse 2025",
+      "path": "Hyper_AF Corse 2025.json"
+    },
+    {
+      "carName": "AM Valkyrie Custom Team 2025",
+      "carId": "Hyper_AM Valkyrie Custom Team 2025",
+      "path": "Hyper_AM Valkyrie Custom Team 2025.json"
+    },
+    {
+      "carName": "Hyper_Alpine Custom Team 2024",
+      "carId": "Hyper_Alpine Custom Team 2024",
+      "path": "Hyper_Alpine Custom Team 2024.json"
+    },
+    {
+      "carName": "Hyper_Alpine Custom Team 2025",
+      "carId": "Hyper_Alpine Custom Team 2025",
+      "path": "Hyper_Alpine Custom Team 2025.json"
+    },
+    {
+      "carName": "Hyper_Alpine Endurance Team 2025",
+      "carId": "Hyper_Alpine Endurance Team 2025",
+      "path": "Hyper_Alpine Endurance Team 2025.json"
+    },
+    {
+      "carName": "Aston Martin THOR Team 2025",
+      "carId": "Hyper_Aston Martin THOR Team 2025",
+      "path": "Hyper_Aston Martin THOR Team 2025.json"
+    },
+    {
+      "carName": "Hyper_BMW M Team WRT 2025",
+      "carId": "Hyper_BMW M Team WRT 2025",
+      "path": "Hyper_BMW M Team WRT 2025.json"
+    },
+    {
+      "carName": "Hyper_BMWMH Custom Team 2024",
+      "carId": "Hyper_BMWMH Custom Team 2024",
+      "path": "Hyper_BMWMH Custom Team 2024.json"
+    },
+    {
+      "carName": "Hyper_BMWMH Custom Team 2025",
+      "carId": "Hyper_BMWMH Custom Team 2025",
+      "path": "Hyper_BMWMH Custom Team 2025.json"
+    },
+    {
+      "carName": "Hyper_BMWMH Custom Team 2025",
+      "carId": "Hyper_BMWMH Custom Team 2025_397",
+      "path": "Hyper_BMWMH Custom Team 2025_397.json"
+    },
+    {
+      "carName": "Hyper_Cadillac Hertz Team Jota 2025",
+      "carId": "Hyper_Cadillac Hertz Team Jota 2025",
+      "path": "Hyper_Cadillac Hertz Team Jota 2025.json"
+    },
+    {
+      "carName": "Hyper_Cadillac WTR 2025",
+      "carId": "Hyper_Cadillac WTR 2025",
+      "path": "Hyper_Cadillac WTR 2025.json"
+    },
+    {
+      "carName": "Hyper_Cadillac Whelen 2025",
+      "carId": "Hyper_Cadillac Whelen 2025",
+      "path": "Hyper_Cadillac Whelen 2025.json"
+    },
+    {
+      "carName": "Hyper_Ferrari AF Corse 2025",
+      "carId": "Hyper_Ferrari AF Corse 2025",
+      "path": "Hyper_Ferrari AF Corse 2025.json"
+    },
+    {
+      "carName": "Hyper_Glickenhaus Custom Team 2023",
+      "carId": "Hyper_Glickenhaus Custom Team 2023",
+      "path": "Hyper_Glickenhaus Custom Team 2023.json"
+    },
+    {
+      "carName": "Hyper_Isotta Fraschini Custom Team 2024",
+      "carId": "Hyper_Isotta Fraschini Custom Team 2024",
+      "path": "Hyper_Isotta Fraschini Custom Team 2024.json"
+    },
+    {
+      "carName": "Hyper_Peugeot 9x8 Custom Team 2023",
+      "carId": "Hyper_Peugeot 9x8 Custom Team 2023",
+      "path": "Hyper_Peugeot 9x8 Custom Team 2023.json"
+    },
+    {
+      "carName": "Hyper_Peugeot TotalEnergies 2025",
+      "carId": "Hyper_Peugeot TotalEnergies 2025",
+      "path": "Hyper_Peugeot TotalEnergies 2025.json"
+    },
+    {
+      "carName": "Hyper_Porsche 963 Custom Team 2023",
+      "carId": "Hyper_Porsche 963 Custom Team 2023",
+      "path": "Hyper_Porsche 963 Custom Team 2023.json"
+    },
+    {
+      "carName": "Hyper_Porsche 963 Custom Team 2024",
+      "carId": "Hyper_Porsche 963 Custom Team 2024",
+      "path": "Hyper_Porsche 963 Custom Team 2024.json"
+    },
+    {
+      "carName": "Hyper_Porsche 963 Custom Team 2025",
+      "carId": "Hyper_Porsche 963 Custom Team 2025",
+      "path": "Hyper_Porsche 963 Custom Team 2025.json"
+    },
+    {
+      "carName": "Hyper_Porsche Penske Motorsport 2025",
+      "carId": "Hyper_Porsche Penske Motorsport 2025",
+      "path": "Hyper_Porsche Penske Motorsport 2025.json"
+    },
+    {
+      "carName": "Hyper_Proton Competition 2025",
+      "carId": "Hyper_Proton Competition 2025",
+      "path": "Hyper_Proton Competition 2025.json"
+    },
+    {
+      "carName": "Hyper_SC63 Custom Team 2024",
+      "carId": "Hyper_SC63 Custom Team 2024",
+      "path": "Hyper_SC63 Custom Team 2024.json"
+    },
+    {
+      "carName": "Hyper_Toyota GR010 Custom Team 2023",
+      "carId": "Hyper_Toyota GR010 Custom Team 2023",
+      "path": "Hyper_Toyota GR010 Custom Team 2023.json"
+    },
+    {
+      "carName": "Hyper_Toyota GR010 Custom Team 2024",
+      "carId": "Hyper_Toyota GR010 Custom Team 2024",
+      "path": "Hyper_Toyota GR010 Custom Team 2024.json"
+    },
+    {
+      "carName": "Hyper_Toyota GR010 Custom Team 2025",
+      "carId": "Hyper_Toyota GR010 Custom Team 2025",
+      "path": "Hyper_Toyota GR010 Custom Team 2025.json"
+    },
+    {
+      "carName": "Hyper_Toyota Gazoo Racing 2025",
+      "carId": "Hyper_Toyota Gazoo Racing 2025",
+      "path": "Hyper_Toyota Gazoo Racing 2025.json"
+    },
+    {
+      "carName": "Hyper_VLMDH Custom Team 2023",
+      "carId": "Hyper_VLMDH Custom Team 2023",
+      "path": "Hyper_VLMDH Custom Team 2023.json"
+    },
+    {
+      "carName": "Hyper_VLMDH Custom Team 2024",
+      "carId": "Hyper_VLMDH Custom Team 2024",
+      "path": "Hyper_VLMDH Custom Team 2024.json"
+    },
+    {
+      "carName": "Hyper_VLMDH Custom Team 2025",
+      "carId": "Hyper_VLMDH Custom Team 2025",
+      "path": "Hyper_VLMDH Custom Team 2025.json"
+    },
+    {
+      "carName": "Hyper_Vanwall Custom Team 2023",
+      "carId": "Hyper_Vanwall Custom Team 2023",
+      "path": "Hyper_Vanwall Custom Team 2023.json"
+    },
+    {
+      "carName": "IDEC Sport 2024",
+      "carId": "IDEC Sport 2024",
+      "path": "IDEC Sport 2024.json"
+    },
+    {
+      "carName": "IDEC Sport",
+      "carId": "IDEC Sport",
+      "path": "IDEC Sport.json"
+    },
+    {
+      "carName": "Inception Racing 2024",
+      "carId": "Inception Racing 2024",
+      "path": "Inception Racing 2024.json"
+    },
+    {
+      "carName": "Inter Europol Competition 2024",
+      "carId": "Inter Europol Competition 2024",
+      "path": "Inter Europol Competition 2024.json"
+    },
+    {
+      "carName": "Inter Europol Competition",
+      "carId": "Inter Europol Competition",
+      "path": "Inter Europol Competition.json"
+    },
+    {
+      "carName": "Iron Dames",
+      "carId": "Iron Dames",
+      "path": "Iron Dames.json"
+    },
+    {
+      "carName": "Iron Lynx",
+      "carId": "Iron Lynx",
+      "path": "Iron Lynx.json"
+    },
+    {
+      "carName": "Isotta TIPO6 2024",
+      "carId": "Isotta TIPO6 2024",
+      "path": "Isotta TIPO6 2024.json"
+    },
+    {
+      "carName": "JMW Motorsport 2024 2024",
+      "carId": "JMW Motorsport 2024 2024",
+      "path": "JMW Motorsport 2024 2024.json"
+    },
+    {
+      "carName": "JMW Motorsport",
+      "carId": "JMW Motorsport",
+      "path": "JMW Motorsport.json"
+    },
+    {
+      "carName": "JOTA 2024",
+      "carId": "JOTA 2024",
+      "path": "JOTA 2024.json"
+    },
+    {
+      "carName": "JOTA",
+      "carId": "JOTA",
+      "path": "JOTA.json"
+    },
+    {
+      "carName": "Kessel Racing",
+      "carId": "Kessel Racing",
+      "path": "Kessel Racing.json"
+    },
+    {
+      "carName": "LMP2_AF Corse 2024",
+      "carId": "LMP2_AF Corse 2024",
+      "path": "LMP2_AF Corse 2024.json"
+    },
+    {
+      "carName": "AF Corse 2025",
+      "carId": "LMP2_AF Corse 2025_183",
+      "path": "LMP2_AF Corse 2025_183.json"
+    },
+    {
+      "carName": "AO by TF 2025",
+      "carId": "LMP2_AO by TF 2025_199",
+      "path": "LMP2_AO by TF 2025_199.json"
+    },
+    {
+      "carName": "Algarve Pro Racing 2025",
+      "carId": "LMP2_Algarve Pro Racing 2025_25",
+      "path": "LMP2_Algarve Pro Racing 2025_25.json"
+    },
+    {
+      "carName": "Algarve Pro Racing 2025",
+      "carId": "LMP2_Algarve Pro Racing 2025_45",
+      "path": "LMP2_Algarve Pro Racing 2025_45.json"
+    },
+    {
+      "carName": "CLX - Pure Rxcing 2025",
+      "carId": "LMP2_CLX - Pure Rxcing 2025_37",
+      "path": "LMP2_CLX - Pure Rxcing 2025_37.json"
+    },
+    {
+      "carName": "AF Corse",
+      "carId": "LMP2_ELMS_AF Corse",
+      "path": "LMP2_ELMS_AF Corse.json"
+    },
+    {
+      "carName": "Ao by TF",
+      "carId": "LMP2_ELMS_AO by TF",
+      "path": "LMP2_ELMS_AO by TF.json"
+    },
+    {
+      "carName": "Algarve Pro Racing",
+      "carId": "LMP2_ELMS_Algarve Pro Racing",
+      "path": "LMP2_ELMS_Algarve Pro Racing.json"
+    },
+    {
+      "carName": "CLX - Pure Rxcing",
+      "carId": "LMP2_ELMS_CLX - Pure Rxcing",
+      "path": "LMP2_ELMS_CLX - Pure Rxcing.json"
+    },
+    {
+      "carName": "CLX Motorsport",
+      "carId": "LMP2_ELMS_CLX Motorsport",
+      "path": "LMP2_ELMS_CLX Motorsport.json"
+    },
+    {
+      "carName": "DKR Engineering",
+      "carId": "LMP2_ELMS_DKR Engineering",
+      "path": "LMP2_ELMS_DKR Engineering.json"
+    },
+    {
+      "carName": "Duqueine Team",
+      "carId": "LMP2_ELMS_Duqueine Team",
+      "path": "LMP2_ELMS_Duqueine Team.json"
+    },
+    {
+      "carName": "IDEC Sport",
+      "carId": "LMP2_ELMS_IDEC Sport",
+      "path": "LMP2_ELMS_IDEC Sport.json"
+    },
+    {
+      "carName": "Inter Europol Competition",
+      "carId": "LMP2_ELMS_Inter Europol Competition",
+      "path": "LMP2_ELMS_Inter Europol Competition.json"
+    },
+    {
+      "carName": "Iron Lynx - Proton",
+      "carId": "LMP2_ELMS_Iron Lynx - Proton",
+      "path": "LMP2_ELMS_Iron Lynx - Proton.json"
+    },
+    {
+      "carName": "Nielsen Racing",
+      "carId": "LMP2_ELMS_Nielsen Racing",
+      "path": "LMP2_ELMS_Nielsen Racing.json"
+    },
+    {
+      "carName": "United Autosports",
+      "carId": "LMP2_ELMS_United Autosports",
+      "path": "LMP2_ELMS_Oreca 07 ELMS Custom Team 2025.json"
+    },
+    {
+      "carName": "Proton Competition",
+      "carId": "LMP2_ELMS_Proton Competition",
+      "path": "LMP2_ELMS_Proton Competition.json"
+    },
+    {
+      "carName": "TDS Racing",
+      "carId": "LMP2_ELMS_TDS Racing",
+      "path": "LMP2_ELMS_TDS Racing.json"
+    },
+    {
+      "carName": "United Autosports",
+      "carId": "LMP2_ELMS_United Autosports",
+      "path": "LMP2_ELMS_United Autosports.json"
+    },
+    {
+      "carName": "VDS Panis Racing",
+      "carId": "LMP2_ELMS_VDS Panis Racing",
+      "path": "LMP2_ELMS_VDS Panis Racing.json"
+    },
+    {
+      "carName": "Vector Sport",
+      "carId": "LMP2_ELMS_Vector Sport",
+      "path": "LMP2_ELMS_Vector Sport.json"
+    },
+    {
+      "carName": "IDEC Sport 2025",
+      "carId": "LMP2_IDEC Sport 2025_18",
+      "path": "LMP2_IDEC Sport 2025_18.json"
+    },
+    {
+      "carName": "IDEC Sport 2025",
+      "carId": "LMP2_IDEC Sport 2025_28",
+      "path": "LMP2_IDEC Sport 2025_28.json"
+    },
+    {
+      "carName": "Inter Europol Competition 2025",
+      "carId": "LMP2_Inter Europol Competition 2025_34",
+      "path": "LMP2_Inter Europol Competition 2025_34.json"
+    },
+    {
+      "carName": "Inter Europol Competition 2025",
+      "carId": "LMP2_Inter Europol Competition 2025_43",
+      "path": "LMP2_Inter Europol Competition 2025_43.json"
+    },
+    {
+      "carName": "Iron Lynx - Proton 2025",
+      "carId": "LMP2_Iron Lynx - Proton 2025_9",
+      "path": "LMP2_Iron Lynx - Proton 2025_9.json"
+    },
+    {
+      "carName": "Nielsen Racing 2025",
+      "carId": "LMP2_Nielsen Racing 2025_24",
+      "path": "LMP2_Nielsen Racing 2025_24.json"
+    },
+    {
+      "carName": "LMP2_Oreca 07 Custom Team 2023",
+      "carId": "LMP2_Oreca 07 Custom Team 2023",
+      "path": "LMP2_Oreca 07 Custom Team 2023.json"
+    },
+    {
+      "carName": "LMP2_Oreca 07 Custom Team 2024",
+      "carId": "LMP2_Oreca 07 Custom Team 2024",
+      "path": "LMP2_Oreca 07 Custom Team 2024.json"
+    },
+    {
+      "carName": "LMP2_Oreca 07 Custom Team 2024",
+      "carId": "LMP2_Oreca 07 Custom Team 2024",
+      "path": "LMP2_Oreca 07 Custom Team 2025.json"
+    },
+    {
+      "carName": "LMP2_Proton Competition 2024",
+      "carId": "LMP2_Proton Competition 2024",
+      "path": "LMP2_Proton Competition 2024.json"
+    },
+    {
+      "carName": "Proton Competition 2025",
+      "carId": "LMP2_Proton Competition 2025_11",
+      "path": "LMP2_Proton Competition 2025_11.json"
+    },
+    {
+      "carName": "RLR MSport 2025",
+      "carId": "LMP2_RLR MSport 2025_16",
+      "path": "LMP2_RLR MSport 2025_16.json"
+    },
+    {
+      "carName": "TDS Racing 2025",
+      "carId": "LMP2_TDS Racing 2025_29",
+      "path": "LMP2_TDS Racing 2025_29.json"
+    },
+    {
+      "carName": "United Autosports 2025",
+      "carId": "LMP2_United Autosports 2025_22",
+      "path": "LMP2_United Autosports 2025_22.json"
+    },
+    {
+      "carName": "United Autosports 2025",
+      "carId": "LMP2_United Autosports 2025_23",
+      "path": "LMP2_United Autosports 2025_23.json"
+    },
+    {
+      "carName": "VDS Panis Racing 2025",
+      "carId": "LMP2_VDS Panis Racing 2025_48",
+      "path": "LMP2_VDS Panis Racing 2025_48.json"
+    },
+    {
+      "carName": "LMP3 Team Virage",
+      "carId": "LMP3_Team Virage",
+      "path": "LMP3_CLX Motorsport.json"
+    },
+    {
+      "carName": "DKR Engineering_4",
+      "carId": "LMP3_DKR Engineering_4",
+      "path": "LMP3_DKR Engineering_4.json"
+    },
+    {
+      "carName": "LMP3 Team Virage",
+      "carId": "LMP3_Team Virage",
+      "path": "LMP3_EuroInternational.json"
+    },
+    {
+      "carName": "Ginetta G61-LT-P3 Custom Team",
+      "carId": "LMP3_Ginetta G61-LT-P3 Custom Team_397",
+      "path": "LMP3_Ginetta G61-LT-P3 Custom Team_397.json"
+    },
+    {
+      "carName": "LMP3 Team Virage",
+      "carId": "LMP3_Team Virage",
+      "path": "LMP3_Inter Europol Competition.json"
+    },
+    {
+      "carName": "LMP3 Team Virage",
+      "carId": "LMP3_Team Virage",
+      "path": "LMP3_Ligier JS P325 Custom Team 2025.json"
+    },
+    {
+      "carName": "LMP3 Team Virage",
+      "carId": "LMP3_Team Virage",
+      "path": "LMP3_M Racing.json"
+    },
+    {
+      "carName": "LMP3 Team Virage",
+      "carId": "LMP3_Team Virage",
+      "path": "LMP3_RLR MSport.json"
+    },
+    {
+      "carName": "LMP3 Team Virage",
+      "carId": "LMP3_Team Virage",
+      "path": "LMP3_Racing Spirit of Léman.json"
+    },
+    {
+      "carName": "LMP3 Team Virage",
+      "carId": "LMP3_Team Virage",
+      "path": "LMP3_Team Virage.json"
+    },
+    {
+      "carName": "LMP3 Team Virage",
+      "carId": "LMP3_Team Virage",
+      "path": "LMP3_Ultimate.json"
+    },
+    {
+      "carName": "Lamborghini Iron Lynx 2024",
+      "carId": "Lamborghini Iron Lynx 2024",
+      "path": "Lamborghini Iron Lynx 2024.json"
+    },
+    {
+      "carName": "Nielsen Racing 2024",
+      "carId": "Nielsen Racing 2024",
+      "path": "Nielsen Racing 2024.json"
+    },
+    {
+      "carName": "Nielsen Racing",
+      "carId": "Nielsen Racing",
+      "path": "Nielsen Racing.json"
+    },
+    {
+      "carName": "Northwest AMR",
+      "carId": "Northwest AMR",
+      "path": "Northwest AMR.json"
+    },
+    {
+      "carName": "ORT by TF",
+      "carId": "ORT by TF",
+      "path": "ORT by TF.json"
+    },
+    {
+      "carName": "Panis Racing 2024",
+      "carId": "Panis Racing 2024",
+      "path": "Panis Racing 2024.json"
+    },
+    {
+      "carName": "Panis Racing",
+      "carId": "Panis Racing",
+      "path": "Panis Racing.json"
+    },
+    {
+      "carName": "Peugeot Sport 2024",
+      "carId": "Peugeot Sport 2024",
+      "path": "Peugeot Sport 2024.json"
+    },
+    {
+      "carName": "Peugeot Sport",
+      "carId": "Peugeot Sport",
+      "path": "Peugeot Sport.json"
+    },
+    {
+      "carName": "Peugeot TotalEnergies 2024",
+      "carId": "Peugeot TotalEnergies 2024",
+      "path": "Peugeot TotalEnergies 2024.json"
+    },
+    {
+      "carName": "Peugeot TotalEnergies",
+      "carId": "Peugeot TotalEnergies",
+      "path": "Peugeot TotalEnergies.json"
+    },
+    {
+      "carName": "Porsche Penske Motorsport 2024",
+      "carId": "Porsche Penske Motorsport 2024",
+      "path": "Porsche Penske Motorsport 2024.json"
+    },
+    {
+      "carName": "Porsche Penske Motorsport",
+      "carId": "Porsche Penske Motorsport",
+      "path": "Porsche Penske Motorsport.json"
+    },
+    {
+      "carName": "Prema Racing 2024",
+      "carId": "Prema Racing 2024",
+      "path": "Prema Racing 2024.json"
+    },
+    {
+      "carName": "Prema Racing",
+      "carId": "Prema Racing",
+      "path": "Prema Racing.json"
+    },
+    {
+      "carName": "Project 1 - AO",
+      "carId": "Project 1 - AO",
+      "path": "Project 1 - AO.json"
+    },
+    {
+      "carName": "Proton Competition 2024",
+      "carId": "Proton Competition 2024",
+      "path": "Proton Competition 2024.json"
+    },
+    {
+      "carName": "Proton Competition GTE",
+      "carId": "Proton Competition GTE",
+      "path": "Proton Competition GTE.json"
+    },
+    {
+      "carName": "Proton Competition",
+      "carId": "Proton Competition",
+      "path": "Proton Competition.json"
+    },
+    {
+      "carName": "Racing Team Turkey 2024",
+      "carId": "Racing Team Turkey 2024",
+      "path": "Racing Team Turkey 2024.json"
+    },
+    {
+      "carName": "Racing Team Turkey",
+      "carId": "Racing Team Turkey",
+      "path": "Racing Team Turkey.json"
+    },
+    {
+      "carName": "Spirit Of Race 2024",
+      "carId": "Spirit Of Race 2024",
+      "path": "Spirit Of Race 2024.json"
+    },
+    {
+      "carName": "TF Sport",
+      "carId": "TF Sport",
+      "path": "TF Sport.json"
+    },
+    {
+      "carName": "Team WRT 2024",
+      "carId": "Team WRT 2024",
+      "path": "Team WRT 2024.json"
+    },
+    {
+      "carName": "Team WRT",
+      "carId": "Team WRT",
+      "path": "Team WRT.json"
+    },
+    {
+      "carName": "The Heart of Racing",
+      "carId": "The Heart of Racing",
+      "path": "The Heart of Racing.json"
+    },
+    {
+      "carName": "Tower Motorsports 2024",
+      "carId": "Tower Motorsports 2024",
+      "path": "Tower Motorsports 2024.json"
+    },
+    {
+      "carName": "Tower Motorsports",
+      "carId": "Tower Motorsports",
+      "path": "Tower Motorsports.json"
+    },
+    {
+      "carName": "Toyota Gazoo Racing 2024",
+      "carId": "Toyota Gazoo Racing 2024",
+      "path": "Toyota Gazoo Racing 2024.json"
+    },
+    {
+      "carName": "Toyota Gazoo Racing",
+      "carId": "Toyota Gazoo Racing",
+      "path": "Toyota Gazoo Racing.json"
+    },
+    {
+      "carName": "United Autosports 2024",
+      "carId": "United Autosports 2024",
+      "path": "United Autosports 2024.json"
+    },
+    {
+      "carName": "United Autosports USA 2024",
+      "carId": "United Autosports USA 2024",
+      "path": "United Autosports USA 2024.json"
+    },
+    {
+      "carName": "United Autosports",
+      "carId": "United Autosports",
+      "path": "United Autosports.json"
+    },
+    {
+      "carName": "Vector Sport 2024",
+      "carId": "Vector Sport 2024",
+      "path": "Vector Sport 2024.json"
+    },
+    {
+      "carName": "Vector Sport",
+      "carId": "Vector Sport",
+      "path": "Vector Sport.json"
+    },
+    {
+      "carName": "Vista AF Corse 2024",
+      "carId": "Vista AF Corse 2024",
+      "path": "Vista AF Corse 2024.json"
+    },
+    {
+      "carName": "Walkenhorst Motorsport",
+      "carId": "Walkenhorst Motorsport",
+      "path": "Walkenhorst Motorsport.json"
+    },
+    {
+      "carName": "Whelen Cadillac Racing 2024",
+      "carId": "Whelen Cadillac Racing 2024",
+      "path": "Whelen Cadillac Racing 2024.json"
+    }
+  ]
+}

--- a/data/RRRE/manifest.json
+++ b/data/RRRE/manifest.json
@@ -1,0 +1,9 @@
+{
+  "cars": [
+    {
+      "carName": "",
+      "carId": "11320,Honda Civic TCR",
+      "path": "11320,Honda Civic TCR.json"
+    }
+  ]
+}

--- a/data/simid/manifest.json
+++ b/data/simid/manifest.json
@@ -1,0 +1,9 @@
+{
+  "cars": [
+    {
+      "carName": "",
+      "carId": "",
+      "path": "carid.json"
+    }
+  ]
+}

--- a/scripts/MANIFEST_GENERATOR.md
+++ b/scripts/MANIFEST_GENERATOR.md
@@ -1,0 +1,59 @@
+# Manifest Generator
+
+Generates `manifest.json` files for each sim data folder, making it easier for consuming applications to discover available cars without scanning directories.
+
+## Usage
+
+```bash
+python3 scripts/generate_manifests.py
+```
+
+The script will:
+- Scan all subdirectories in `data/`
+- Read each car JSON file
+- Extract `carName`, `carId`, and filename
+- Generate a `manifest.json` in each sim folder
+- Report any errors or invalid files
+
+## Output Format
+
+Each `manifest.json` contains:
+
+```json
+{
+  "cars": [
+    {
+      "carName": "Ferrari 488 GT3",
+      "carId": "ferrari_488_gt3",
+      "path": "ferrari_488_gt3.json"
+    }
+  ]
+}
+```
+
+## Testing
+
+Run the test suite:
+
+```bash
+python3 scripts/test_generate_manifests.py
+```
+
+For verbose output:
+
+```bash
+python3 scripts/test_generate_manifests.py -v
+```
+
+## Requirements
+
+- Python 3.6+
+- No external dependencies
+
+## Error Handling
+
+The script will:
+- Skip files with invalid JSON
+- Skip files missing required `carId` field
+- Report all errors but continue processing
+- Only create manifest if at least one valid car exists

--- a/scripts/generate_manifests.py
+++ b/scripts/generate_manifests.py
@@ -1,0 +1,87 @@
+#!/usr/bin/env python3
+"""Generate manifest.json files for each sim data folder."""
+
+import json
+import sys
+from pathlib import Path
+from typing import Dict, List
+
+
+def load_car_data(car_file: Path) -> Dict[str, str]:
+    """Load car data from JSON file and extract required fields."""
+    with open(car_file, 'r', encoding='utf-8') as f:
+        data = json.load(f)
+    
+    car_name = data.get("carName", "")
+    car_id = data.get("carId", "")
+    
+    if not car_id:
+        raise ValueError(f"Missing carId in {car_file}")
+    
+    return {
+        "carName": car_name,
+        "carId": car_id,
+        "path": car_file.name
+    }
+
+
+def generate_manifest(sim_folder: Path) -> int:
+    """Generate manifest.json for a sim folder. Returns number of cars."""
+    cars: List[Dict[str, str]] = []
+    errors: List[str] = []
+    
+    for car_file in sorted(sim_folder.glob("*.json")):
+        if car_file.name == "manifest.json":
+            continue
+        
+        try:
+            cars.append(load_car_data(car_file))
+        except (json.JSONDecodeError, ValueError) as e:
+            errors.append(f"  {car_file.name}: {e}")
+    
+    if errors:
+        print(f"⚠️  {sim_folder.name}: Skipped {len(errors)} file(s)")
+        for error in errors:
+            print(error)
+    
+    if not cars:
+        return 0
+    
+    manifest = {"cars": cars}
+    manifest_path = sim_folder / "manifest.json"
+    
+    with open(manifest_path, 'w', encoding='utf-8') as f:
+        json.dump(manifest, f, indent=2, ensure_ascii=False)
+        f.write('\n')
+    
+    print(f"✓ {sim_folder.name}: {len(cars)} car(s)")
+    return len(cars)
+
+
+def main() -> int:
+    """Main entry point."""
+    script_dir = Path(__file__).parent
+    data_dir = script_dir.parent / "data"
+    
+    if not data_dir.exists():
+        print(f"Error: data directory not found at {data_dir}", file=sys.stderr)
+        return 1
+    
+    total_cars = 0
+    total_sims = 0
+    
+    for sim_folder in sorted(data_dir.iterdir()):
+        if not sim_folder.is_dir() or sim_folder.name.startswith('.'):
+            continue
+        
+        car_count = generate_manifest(sim_folder)
+        if car_count > 0:
+            total_cars += car_count
+            total_sims += 1
+    
+    print(f"\n✓ Generated {total_sims} manifest(s) with {total_cars} total car(s)")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/test_generate_manifests.py
+++ b/scripts/test_generate_manifests.py
@@ -1,0 +1,193 @@
+#!/usr/bin/env python3
+"""Tests for generate_manifests.py"""
+
+import json
+import tempfile
+import unittest
+from pathlib import Path
+
+import generate_manifests
+
+
+class TestGenerateManifests(unittest.TestCase):
+    """Test suite for manifest generation."""
+    
+    def setUp(self):
+        """Create temporary test directory structure."""
+        self.temp_dir = tempfile.TemporaryDirectory()
+        self.data_dir = Path(self.temp_dir.name) / "data"
+        self.data_dir.mkdir()
+    
+    def tearDown(self):
+        """Clean up temporary directory."""
+        self.temp_dir.cleanup()
+    
+    def create_car_file(self, sim_name: str, filename: str, car_data: dict):
+        """Helper to create a car JSON file."""
+        sim_dir = self.data_dir / sim_name
+        sim_dir.mkdir(exist_ok=True)
+        car_file = sim_dir / filename
+        with open(car_file, 'w', encoding='utf-8') as f:
+            json.dump(car_data, f)
+        return car_file
+    
+    def test_load_car_data_valid(self):
+        """Test loading valid car data."""
+        car_file = self.create_car_file("TestSim", "test_car.json", {
+            "carName": "Test Car",
+            "carId": "test_car",
+            "ledNumber": 5
+        })
+        
+        result = generate_manifests.load_car_data(car_file)
+        
+        self.assertEqual(result["carName"], "Test Car")
+        self.assertEqual(result["carId"], "test_car")
+        self.assertEqual(result["path"], "test_car.json")
+    
+    def test_load_car_data_missing_car_name(self):
+        """Test loading car data with missing carName (should use empty string)."""
+        car_file = self.create_car_file("TestSim", "test_car.json", {
+            "carId": "test_car"
+        })
+        
+        result = generate_manifests.load_car_data(car_file)
+        
+        self.assertEqual(result["carName"], "")
+        self.assertEqual(result["carId"], "test_car")
+    
+    def test_load_car_data_missing_car_id(self):
+        """Test loading car data with missing carId (should raise error)."""
+        car_file = self.create_car_file("TestSim", "test_car.json", {
+            "carName": "Test Car"
+        })
+        
+        with self.assertRaises(ValueError):
+            generate_manifests.load_car_data(car_file)
+    
+    def test_load_car_data_unicode(self):
+        """Test loading car data with unicode characters."""
+        car_file = self.create_car_file("TestSim", "test_car.json", {
+            "carName": "Lamborghini Huracán EVO",
+            "carId": "lamborghini_huracan_evo"
+        })
+        
+        result = generate_manifests.load_car_data(car_file)
+        
+        self.assertEqual(result["carName"], "Lamborghini Huracán EVO")
+    
+    def test_generate_manifest_single_car(self):
+        """Test generating manifest with single car."""
+        self.create_car_file("TestSim", "car1.json", {
+            "carName": "Car 1",
+            "carId": "car_1"
+        })
+        
+        sim_dir = self.data_dir / "TestSim"
+        count = generate_manifests.generate_manifest(sim_dir)
+        
+        self.assertEqual(count, 1)
+        
+        manifest_file = sim_dir / "manifest.json"
+        self.assertTrue(manifest_file.exists())
+        
+        with open(manifest_file, 'r', encoding='utf-8') as f:
+            manifest = json.load(f)
+        
+        self.assertEqual(len(manifest["cars"]), 1)
+        self.assertEqual(manifest["cars"][0]["carName"], "Car 1")
+    
+    def test_generate_manifest_multiple_cars(self):
+        """Test generating manifest with multiple cars."""
+        self.create_car_file("TestSim", "car1.json", {
+            "carName": "Car 1",
+            "carId": "car_1"
+        })
+        self.create_car_file("TestSim", "car2.json", {
+            "carName": "Car 2",
+            "carId": "car_2"
+        })
+        
+        sim_dir = self.data_dir / "TestSim"
+        count = generate_manifests.generate_manifest(sim_dir)
+        
+        self.assertEqual(count, 2)
+        
+        with open(sim_dir / "manifest.json", 'r', encoding='utf-8') as f:
+            manifest = json.load(f)
+        
+        self.assertEqual(len(manifest["cars"]), 2)
+        self.assertEqual(manifest["cars"][0]["carId"], "car_1")
+        self.assertEqual(manifest["cars"][1]["carId"], "car_2")
+    
+    def test_generate_manifest_sorted_order(self):
+        """Test that cars are sorted alphabetically by filename."""
+        self.create_car_file("TestSim", "zebra.json", {
+            "carName": "Zebra",
+            "carId": "zebra"
+        })
+        self.create_car_file("TestSim", "alpha.json", {
+            "carName": "Alpha",
+            "carId": "alpha"
+        })
+        
+        sim_dir = self.data_dir / "TestSim"
+        generate_manifests.generate_manifest(sim_dir)
+        
+        with open(sim_dir / "manifest.json", 'r', encoding='utf-8') as f:
+            manifest = json.load(f)
+        
+        self.assertEqual(manifest["cars"][0]["carId"], "alpha")
+        self.assertEqual(manifest["cars"][1]["carId"], "zebra")
+    
+    def test_generate_manifest_skips_invalid_files(self):
+        """Test that invalid files are skipped with error reporting."""
+        self.create_car_file("TestSim", "valid.json", {
+            "carName": "Valid",
+            "carId": "valid"
+        })
+        self.create_car_file("TestSim", "invalid.json", {
+            "carName": "Invalid"
+            # Missing carId
+        })
+        
+        sim_dir = self.data_dir / "TestSim"
+        count = generate_manifests.generate_manifest(sim_dir)
+        
+        self.assertEqual(count, 1)
+        
+        with open(sim_dir / "manifest.json", 'r', encoding='utf-8') as f:
+            manifest = json.load(f)
+        
+        self.assertEqual(len(manifest["cars"]), 1)
+        self.assertEqual(manifest["cars"][0]["carId"], "valid")
+    
+    def test_generate_manifest_empty_folder(self):
+        """Test generating manifest for empty folder."""
+        sim_dir = self.data_dir / "EmptySim"
+        sim_dir.mkdir()
+        
+        count = generate_manifests.generate_manifest(sim_dir)
+        
+        self.assertEqual(count, 0)
+        self.assertFalse((sim_dir / "manifest.json").exists())
+    
+    def test_generate_manifest_ignores_existing_manifest(self):
+        """Test that existing manifest.json is not processed as a car file."""
+        self.create_car_file("TestSim", "car1.json", {
+            "carName": "Car 1",
+            "carId": "car_1"
+        })
+        
+        # Create an existing manifest
+        sim_dir = self.data_dir / "TestSim"
+        with open(sim_dir / "manifest.json", 'w') as f:
+            json.dump({"cars": []}, f)
+        
+        count = generate_manifests.generate_manifest(sim_dir)
+        
+        self.assertEqual(count, 1)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
- Add manifest.json to each sim folder listing all available cars
- Each manifest contains carName, carId, and path for easy discovery
- Add scripts/generate_manifests.py to regenerate manifests
- Add comprehensive test suite with 10 unit tests
- Update README with manifest documentation
- Simplifies integration for consuming applications